### PR TITLE
docs: add TaskFlow run report

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 BudgetIQ is an open-source, intelligent personal finance manager. It features Google & Discord authentication, interactive financial tracking (Salary, Expenses, Assets), daily motivational quotes, and a built-in AI chatbot powered by the Google Gemini Free API that can naturally parse user conversation and automatically suggest adding transactions directly to your dashboard.
 
+> 🗂️ See [`docs/taskflow.md`](docs/taskflow.md) for the project task flow (GitHub Project board + 14 implementation-ready issues).
+
 ## 🌟 Features
 
 - 🔐 **Authentication**: Single-click OAuth Login with Google & Discord via Supabase Auth.

--- a/docs/taskflow.md
+++ b/docs/taskflow.md
@@ -1,0 +1,84 @@
+# BudgetIQ — TaskFlow Run Report
+
+This document records the result of running the [TaskFlow](https://github.com/invictusdhahri/taskflow) agent skill (created by **invictusdhahri**) against the BudgetIQ repository on 2026-08-02.
+
+## What was done
+
+TaskFlow detected **Mode 2 — Repository Without Applicable Project** (repo exists, no BudgetIQ Project). After evidence gathering and an approved change plan (`Plan v1`), it created a GitHub Project, a Board view, a Priority field, and 14 implementation-ready issues covering the features defined in the README.
+
+## Project
+
+- **Title:** BudgetIQ
+- **URL:** https://github.com/users/AmineMabrouk17/projects/4
+- **Linked repository:** `AmineMabrouk17/BudgetIQ`
+- **Views:** Board (default for Status columns)
+- **Status field options:** Backlog, Ready, Todo, In Progress, In review, Done
+- **Priority field options:** Critical, High, Medium, Low
+
+## Issues (#1–#14)
+
+All issues are assigned to @AmineMabrouk17, labelled `enhancement`, with Status `Backlog` in the Project. Each issue follows the TaskFlow issue contract (Caveman, Files to change, acceptance criteria, test plan, NFRs, dependencies).
+
+| # | Title | Wave | Priority | Blocked by |
+|---|-------|------|----------|------------|
+| 1 | Scaffold Next.js app with Tailwind, DaisyUI, and Lucide React | Foundation | High | — |
+| 2 | Set up Supabase client layer and environment configuration | Foundation | High | #1 |
+| 3 | Add transactions database schema with RLS policies | Foundation | High | #2 |
+| 4 | Implement Google and Discord OAuth sign-in | Auth | High | #2 |
+| 5 | Protect dashboard routes with session check | Auth | High | #4 |
+| 6 | Implement transactions data layer with server actions | Dashboard | High | #3 |
+| 7 | Build dashboard summary cards | Dashboard | Medium | #6 |
+| 8 | Add interactive category breakdown chart | Dashboard | Medium | #6 |
+| 9 | Build transaction table with add and delete | Dashboard | Medium | #6 |
+| 10 | Implement Gemini chat API route with structured JSON parsing | AI | High | #6 |
+| 11 | Build AI chatbot drawer with add-transaction action | AI | Medium | #10 |
+| 12 | Add daily financial quotes API and display | AI | Low | #1 |
+| 13 | Build navbar with auth status and theme toggle | Polish | Medium | #5 |
+| 14 | Deploy BudgetIQ to Vercel with environment configuration | Deploy | Medium | #1 |
+
+### Delivery waves
+
+1. **Foundation** — #1, #2, #3
+2. **Auth** — #4, #5
+3. **Dashboard** — #6, #7, #8, #9
+4. **AI** — #10, #11, #12
+5. **Polish & Deploy** — #13, #14
+
+### Critical path
+
+`#1 → #2 → #4 → #5 → #6 → #7 → #10 → #11 → #13 → #14`
+
+## Verification report — Plan v1
+
+```
+VERIFY — Plan v1
+
+Ledger
+- OP-01 CREATE_PROJECT — success — https://github.com/users/AmineMabrouk17/projects/4 — verified yes
+- OP-02 CREATE_VIEW Board — success (grouping by Status must be set in UI) — verified yes
+- OP-03 CREATE_FIELD Priority + Status options — success — verified yes
+- OP-04 CREATE_ISSUE #1..#14 — success — verified yes (assignee + label set)
+- OP-05 RELATE blocked-by edges — success — 13 edges verified
+- OP-06 VERIFY — success
+
+Expected vs actual
+- Repository: AmineMabrouk17/BudgetIQ (PUBLIC, issues enabled) — matches
+- Project / fields / workflows: BudgetIQ Project #4, Board view, Status + Priority fields — matches
+- Issues / relationships: 14 issues, 13 blocked-by edges — matches
+- Project items / statuses: all 14 items Status=Backlog, priority set — matches
+
+Unexpected changes or duplicates
+- None
+
+Residual plan
+- Not required. Board grouping to Status is a one-step UI fallback
+  (Project → BudgetIQ → Board view → Group by Status), because the
+  Projects API cannot set view grouping.
+```
+
+## Usage
+
+- **Board:** https://github.com/users/AmineMabrouk17/projects/4
+- **Issues:** https://github.com/AmineMabrouk17/BudgetIQ/issues
+
+Follow the dependency order (critical path above) when implementing. Move items through Backlog → Ready → In Progress → In review → Done as work progresses.


### PR DESCRIPTION
Adds `docs/taskflow.md`, a report documenting the TaskFlow skill run (created by invictusdhahri) that set up the BudgetIQ GitHub Project board and 14 implementation-ready issues (#1–#14).

- Documents the Project (views, Status/Priority fields), issue table with delivery waves, critical path, and the Plan v1 verification report.
- Links the report from the README.

Project: https://github.com/users/AmineMabrouk17/projects/4