### PR TITLE
feat: add Google OAuth and email/password sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ FOR ALL
 USING (auth.uid() = user_id);
 ```
 
+> User profiles are handled by `supabase/migrations/0002_profiles.sql` — run it from the SQL Editor to create the `profiles` table, its RLS policies, and a trigger that auto-creates a profile on signup (name & avatar are pulled from the Google provider, or from the signup form for email accounts).
+
 ### 5. Configure OAuth Providers in Supabase
 
 1. Navigate to Supabase Dashboard ➔ Authentication ➔ Providers.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ USING (auth.uid() = user_id);
 3. **Discord Setup**: Enable Discord and paste your Client ID & Client Secret from Discord Developer Portal.
 4. Add Callback URL in both Google & Discord:
    `https://<YOUR_SUPABASE_PROJECT_REF>.supabase.co/auth/v1/callback`
+5. Navigate to Authentication ➔ URL Configuration and add `http://localhost:3000/auth/callback` to **Redirect URLs** so Supabase can send users back to the app after sign-in.
 
 ### 6. Run Locally
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 🤖 BudgetIQ - AI-Powered Personal Finance & Budget Planner
 
-BudgetIQ is an open-source, intelligent personal finance manager. It features Google & Discord authentication, interactive financial tracking (Salary, Expenses, Assets), daily motivational quotes, and a built-in AI chatbot powered by the Google Gemini Free API that can naturally parse user conversation and automatically suggest adding transactions directly to your dashboard.
+BudgetIQ is an open-source, intelligent personal finance manager. It features Google sign-in & email authentication, interactive financial tracking (Salary, Expenses, Assets), daily motivational quotes, and a built-in AI chatbot powered by the Google Gemini Free API that can naturally parse user conversation and automatically suggest adding transactions directly to your dashboard.
 
 > 🗂️ See [`docs/taskflow.md`](docs/taskflow.md) for the project task flow (GitHub Project board + 14 implementation-ready issues).
 
 ## 🌟 Features
 
-- 🔐 **Authentication**: Single-click OAuth Login with Google & Discord via Supabase Auth.
+- 🔐 **Authentication**: One-click sign-in with Google (OAuth) or email & password, both via Supabase Auth.
 - 📊 **Comprehensive Dashboard**:
   - Track Salary / Income, Expenses, and Assets.
   - Real-time financial summary cards (Net Balance, Monthly Spending, Total Assets).
@@ -128,10 +128,11 @@ USING (auth.uid() = user_id);
 
 1. Navigate to Supabase Dashboard ➔ Authentication ➔ Providers.
 2. **Google Setup**: Enable Google and paste your Client ID & Client Secret from Google Cloud Console.
-3. **Discord Setup**: Enable Discord and paste your Client ID & Client Secret from Discord Developer Portal.
-4. Add Callback URL in both Google & Discord:
+3. Add Callback URL in Google:
    `https://<YOUR_SUPABASE_PROJECT_REF>.supabase.co/auth/v1/callback`
-5. Navigate to Authentication ➔ URL Configuration and add `http://localhost:3000/auth/callback` to **Redirect URLs** so Supabase can send users back to the app after sign-in.
+4. Navigate to Authentication ➔ URL Configuration and add `http://localhost:3000/auth/callback` to **Redirect URLs** so Supabase can send users back to the app after sign-in.
+
+Email & password sign-in is built into Supabase Auth — just make sure the **Email** provider is enabled (default). Email confirmations can be toggled under Authentication ➔ Providers ➔ Email in the **Confirm email** setting.
 
 ### 6. Run Locally
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,22 @@ USING (auth.uid() = user_id);
 
 Email & password sign-in is built into Supabase Auth — just make sure the **Email** provider is enabled (default). Email confirmations can be toggled under Authentication ➔ Providers ➔ Email in the **Confirm email** setting.
 
-### 6. Run Locally
+### 6. Configure Email (SMTP with Resend)
+
+Supabase's default email service only sends ~2 emails/hour, so verification and password-reset emails won't reliably arrive. Use [Resend](https://resend.com) as the SMTP provider for both dev and production:
+
+1. Create a free account at resend.com and verify a domain you own (Settings ➔ Domains). Without a domain, you can test by sending from `onboarding@resend.dev`.
+2. Grab your SMTP credentials: resend.com ➔ Settings ➔ SMTP:
+   - **Host:** `smtp.resend.com`
+   - **Port:** `587` (or `465` for SSL)
+   - **Username:** `resend`
+   - **Password:** your Resend API key (`re_...`)
+3. In Supabase ➔ Authentication ➔ SMTP, paste the host/port/user/password, set a **Sender email** (e.g. `onboarding@resend.dev` for testing, or `no-reply@yourdomain.com`), and save.
+4. Optional: to sign up instantly without an email, turn off **Confirm email** under Authentication ➔ Providers ➔ Email. Turn it back on once SMTP is configured for production.
+
+> Store the Resend API key only in the Supabase dashboard — never commit it to the repository.
+
+### 7. Run Locally
 
 ```bash
 npm run dev

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,19 @@
+import { Wallet } from "lucide-react";
+
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-base-200 p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 flex items-center justify-center gap-3">
+          <Wallet className="h-10 w-10 text-primary" />
+          <span className="text-3xl font-bold text-base-content">BudgetIQ</span>
+        </div>
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,35 +1,74 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import type { FormEvent } from "react";
+import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
-import { Loader2, MessageCircle, Globe } from "lucide-react";
+import { Loader2, Globe, Mail } from "lucide-react";
 
-type Provider = "google" | "discord";
-
-const providers: { id: Provider; label: string; icon: typeof Globe }[] = [
-  { id: "google", label: "Continue with Google", icon: Globe },
-  { id: "discord", label: "Continue with Discord", icon: MessageCircle },
-];
+type Mode = "signin" | "signup";
 
 export default function LoginPage() {
-  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
-  const [, startTransition] = useTransition();
+  const [mode, setMode] = useState<Mode>("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pendingOAuth, setPendingOAuth] = useState(false);
+  const [pendingEmail, setPendingEmail] = useState(false);
   const searchParams = useSearchParams();
-  const error = searchParams.get("error");
+  const callbackError = searchParams.get("error");
 
-  function signIn(provider: Provider) {
-    const supabase = createClient();
-    setPendingProvider(provider);
-    startTransition(async () => {
-      await supabase.auth.signInWithOAuth({
-        provider,
-        options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
-        },
-      });
-      setPendingProvider(null);
+  const supabase = createClient();
+
+  async function signInWithGoogle() {
+    setError(null);
+    setMessage(null);
+    setPendingOAuth(true);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
+    if (error) {
+      setError(error.message);
+      setPendingOAuth(false);
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setPendingEmail(true);
+
+    if (mode === "signup") {
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+      });
+      if (error) {
+        setError(error.message);
+      } else if (data.session) {
+        window.location.href = "/";
+      } else {
+        setMessage(
+          "Check your inbox for a verification email to confirm your account."
+        );
+      }
+    } else {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (error) {
+        setError(error.message);
+      } else {
+        window.location.href = "/";
+      }
+    }
+
+    setPendingEmail(false);
   }
 
   return (
@@ -37,28 +76,93 @@ export default function LoginPage() {
       <div className="card-body">
         <h2 className="card-title justify-center text-2xl">Sign in to BudgetIQ</h2>
         <p className="text-center text-sm text-base-content/70">
-          Track your income, expenses, and assets with one-click sign-in.
+          Track your income, expenses, and assets.
         </p>
+
         <div className="mt-4 flex flex-col gap-3">
-          {providers.map(({ id, label, icon: Icon }) => (
-            <button
-              key={id}
-              className="btn btn-outline"
-              onClick={() => signIn(id)}
-              disabled={pendingProvider !== null}
-            >
-              {pendingProvider === id ? (
-                <Loader2 className="animate-spin" />
-              ) : (
-                <Icon />
-              )}
-              {label}
-            </button>
-          ))}
+          <button
+            className="btn btn-outline"
+            onClick={signInWithGoogle}
+            disabled={pendingOAuth || pendingEmail}
+          >
+            {pendingOAuth ? <Loader2 className="animate-spin" /> : <Globe />}
+            Continue with Google
+          </button>
         </div>
-        {error && (
+
+        <div className="divider my-4">or</div>
+
+        <div role="tablist" className="tabs tabs-lift">
+          <button
+            role="tab"
+            className={`tab ${mode === "signin" ? "tab-active" : ""}`}
+            onClick={() => {
+              setMode("signin");
+              setError(null);
+              setMessage(null);
+            }}
+          >
+            Sign in
+          </button>
+          <button
+            role="tab"
+            className={`tab ${mode === "signup" ? "tab-active" : ""}`}
+            onClick={() => {
+              setMode("signup");
+              setError(null);
+              setMessage(null);
+            }}
+          >
+            Create account
+          </button>
+        </div>
+
+        <form className="mt-4 flex flex-col gap-3" onSubmit={handleSubmit}>
+          <label className="form-control w-full">
+            <span className="label-text mb-1">Email</span>
+            <input
+              className="input input-bordered w-full"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+            />
+          </label>
+          <label className="form-control w-full">
+            <span className="label-text mb-1">Password</span>
+            <input
+              className="input input-bordered w-full"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              autoComplete={mode === "signup" ? "new-password" : "current-password"}
+            />
+          </label>
+          <button
+            className="btn btn-primary mt-2"
+            disabled={pendingEmail || pendingOAuth}
+          >
+            {pendingEmail ? <Loader2 className="animate-spin" /> : <Mail />}
+            {mode === "signin" ? "Sign in" : "Create account"}
+          </button>
+        </form>
+
+        {callbackError && (
           <div className="alert alert-error mt-4">
             <span>Sign-in failed. Please try again.</span>
+          </div>
+        )}
+        {error && (
+          <div className="alert alert-error mt-4">
+            <span>{error}</span>
+          </div>
+        )}
+        {message && (
+          <div className="alert alert-success mt-4">
+            <span>{message}</span>
           </div>
         )}
       </div>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,9 +4,56 @@ import type { FormEvent } from "react";
 import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
-import { Loader2, Globe, Mail } from "lucide-react";
+import { Loader2, Globe, Mail, Send } from "lucide-react";
 
 type Mode = "signin" | "signup";
+type ErrorAction = "switchToSignIn" | "switchToSignUp" | "resend" | null;
+
+type AuthError = { code?: string; message?: string } | null;
+
+function friendlyError(
+  error: AuthError
+): { message: string; action: ErrorAction } {
+  const code = error?.code ?? "";
+  const message = error?.message ?? "";
+  const lower = message.toLowerCase();
+
+  if (code === "user_already_exists" || lower.includes("already registered")) {
+    return {
+      message: "An account with this email already exists. Sign in instead.",
+      action: "switchToSignIn",
+    };
+  }
+  if (code === "invalid_credentials") {
+    return { message: "Incorrect email or password.", action: null };
+  }
+  if (code === "email_not_confirmed") {
+    return {
+      message:
+        "Your email isn't confirmed yet. Check your inbox (and spam) for the confirmation link.",
+      action: "resend",
+    };
+  }
+  if (code === "weak_password") {
+    return {
+      message: "Password is too weak — use at least 6 characters.",
+      action: null,
+    };
+  }
+  if (code === "over_email_send_rate_limit") {
+    return {
+      message: "Too many confirmation emails sent. Please wait a moment and try again.",
+      action: null,
+    };
+  }
+  if (lower.includes("invalid email")) {
+    return { message: "Please enter a valid email address.", action: null };
+  }
+  return {
+    message: message || "Something went wrong. Please try again.",
+    action: null,
+  };
+}
 
 export default function LoginPage() {
   const [mode, setMode] = useState<Mode>("signin");
@@ -15,6 +62,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [errorAction, setErrorAction] = useState<ErrorAction>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [pendingOAuth, setPendingOAuth] = useState(false);
   const [pendingEmail, setPendingEmail] = useState(false);
@@ -22,6 +70,23 @@ export default function LoginPage() {
   const callbackError = searchParams.get("error");
 
   const supabase = createClient();
+
+  function switchMode(next: Mode) {
+    setMode(next);
+    setError(null);
+    setErrorAction(null);
+    setMessage(null);
+  }
+
+  function applyError(error: AuthError) {
+    const { message, action } = friendlyError(error);
+    setError(message);
+    setErrorAction(action);
+    if (action === "switchToSignIn") {
+      setMode("signin");
+      setPassword("");
+    }
+  }
 
   async function signInWithGoogle() {
     setError(null);
@@ -32,14 +97,35 @@ export default function LoginPage() {
       options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
     if (error) {
-      setError(error.message);
+      applyError(error);
       setPendingOAuth(false);
+    }
+  }
+
+  async function resendConfirmation() {
+    setError(null);
+    setMessage(null);
+    setPendingEmail(true);
+    const { error } = await supabase.auth.resend({
+      type: "signup",
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+    });
+    setPendingEmail(false);
+    if (error) {
+      applyError(error);
+    } else {
+      setErrorAction(null);
+      setMessage(
+        "Confirmation email sent. Check your inbox (and spam) to verify your account."
+      );
     }
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setErrorAction(null);
     setMessage(null);
     setPendingEmail(true);
 
@@ -53,12 +139,13 @@ export default function LoginPage() {
         },
       });
       if (error) {
-        setError(error.message);
+        applyError(error);
       } else if (data.session) {
         window.location.href = "/";
       } else {
+        setErrorAction("resend");
         setMessage(
-          "Check your inbox for a verification email to confirm your account."
+          `We sent a confirmation link to ${email}. Check your inbox (and spam) to verify your account.`
         );
       }
     } else {
@@ -67,7 +154,7 @@ export default function LoginPage() {
         password,
       });
       if (error) {
-        setError(error.message);
+        applyError(error);
       } else {
         window.location.href = "/";
       }
@@ -101,22 +188,14 @@ export default function LoginPage() {
           <button
             role="tab"
             className={`tab ${mode === "signin" ? "tab-active" : ""}`}
-            onClick={() => {
-              setMode("signin");
-              setError(null);
-              setMessage(null);
-            }}
+            onClick={() => switchMode("signin")}
           >
             Sign in
           </button>
           <button
             role="tab"
             className={`tab ${mode === "signup" ? "tab-active" : ""}`}
-            onClick={() => {
-              setMode("signup");
-              setError(null);
-              setMessage(null);
-            }}
+            onClick={() => switchMode("signup")}
           >
             Create account
           </button>
@@ -190,6 +269,16 @@ export default function LoginPage() {
           <div className="alert alert-error mt-4">
             <span>{error}</span>
           </div>
+        )}
+        {errorAction === "resend" && (
+          <button
+            className="btn btn-ghost btn-sm mt-2"
+            onClick={resendConfirmation}
+            disabled={pendingEmail}
+          >
+            {pendingEmail ? <Loader2 className="animate-spin" /> : <Send />}
+            Resend confirmation email
+          </button>
         )}
         {message && (
           <div className="alert alert-success mt-4">

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,24 +1,26 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
-import { Loader2, MessageCircle, Chrome } from "lucide-react";
+import { Loader2, MessageCircle, Globe } from "lucide-react";
 
 type Provider = "google" | "discord";
 
-const providers: { id: Provider; label: string; icon: typeof Chrome }[] = [
-  { id: "google", label: "Continue with Google", icon: Chrome },
+const providers: { id: Provider; label: string; icon: typeof Globe }[] = [
+  { id: "google", label: "Continue with Google", icon: Globe },
   { id: "discord", label: "Continue with Discord", icon: MessageCircle },
 ];
 
 export default function LoginPage() {
-  const [pendingProvider, startTransition] = useTransition();
+  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
+  const [, startTransition] = useTransition();
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
 
   function signIn(provider: Provider) {
     const supabase = createClient();
+    setPendingProvider(provider);
     startTransition(async () => {
       await supabase.auth.signInWithOAuth({
         provider,
@@ -26,6 +28,7 @@ export default function LoginPage() {
           redirectTo: `${window.location.origin}/auth/callback`,
         },
       });
+      setPendingProvider(null);
     });
   }
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useTransition } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useSearchParams } from "next/navigation";
+import { Loader2, MessageCircle, Chrome } from "lucide-react";
+
+type Provider = "google" | "discord";
+
+const providers: { id: Provider; label: string; icon: typeof Chrome }[] = [
+  { id: "google", label: "Continue with Google", icon: Chrome },
+  { id: "discord", label: "Continue with Discord", icon: MessageCircle },
+];
+
+export default function LoginPage() {
+  const [pendingProvider, startTransition] = useTransition();
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+
+  function signIn(provider: Provider) {
+    const supabase = createClient();
+    startTransition(async () => {
+      await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+    });
+  }
+
+  return (
+    <div className="card w-full bg-base-100 shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title justify-center text-2xl">Sign in to BudgetIQ</h2>
+        <p className="text-center text-sm text-base-content/70">
+          Track your income, expenses, and assets with one-click sign-in.
+        </p>
+        <div className="mt-4 flex flex-col gap-3">
+          {providers.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              className="btn btn-outline"
+              onClick={() => signIn(id)}
+              disabled={pendingProvider !== null}
+            >
+              {pendingProvider === id ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <Icon />
+              )}
+              {label}
+            </button>
+          ))}
+        </div>
+        {error && (
+          <div className="alert alert-error mt-4">
+            <span>Sign-in failed. Please try again.</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -10,6 +10,8 @@ type Mode = "signin" | "signup";
 
 export default function LoginPage() {
   const [mode, setMode] = useState<Mode>("signin");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -45,7 +47,10 @@ export default function LoginPage() {
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
-        options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+        options: {
+          data: { full_name: `${firstName.trim()} ${lastName.trim()}`.trim() },
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
+        },
       });
       if (error) {
         setError(error.message);
@@ -118,6 +123,32 @@ export default function LoginPage() {
         </div>
 
         <form className="mt-4 flex flex-col gap-3" onSubmit={handleSubmit}>
+          {mode === "signup" && (
+            <div className="flex gap-3">
+              <label className="form-control w-full">
+                <span className="label-text mb-1">First name</span>
+                <input
+                  className="input input-bordered w-full"
+                  type="text"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  required
+                  autoComplete="given-name"
+                />
+              </label>
+              <label className="form-control w-full">
+                <span className="label-text mb-1">Last name</span>
+                <input
+                  className="input input-bordered w-full"
+                  type="text"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  required
+                  autoComplete="family-name"
+                />
+              </label>
+            </div>
+          )}
           <label className="form-control w-full">
             <span className="label-text mb-1">Email</span>
             <input

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -142,6 +142,15 @@ export default function LoginPage() {
         applyError(error);
       } else if (data.session) {
         window.location.href = "/";
+      } else if (
+        data.user &&
+        Array.isArray(data.user.identities) &&
+        data.user.identities.length === 0
+      ) {
+        applyError({
+          code: "user_already_exists",
+          message: "User already registered",
+        });
       } else {
         setErrorAction("resend");
         setMessage(

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/");
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      const forwardedHost = request.headers.get("x-forwarded-host");
+      const isLocalEnv = process.env.NODE_ENV === "development";
+      if (isLocalEnv && forwardedHost) {
+        return NextResponse.redirect(
+          new URL(`http://${forwardedHost}${next}`, origin)
+        );
+      }
+      return NextResponse.redirect(new URL(next, origin));
+    }
+  }
+
+  return NextResponse.redirect(new URL("/login?error=auth_failed", origin));
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,51 @@
-import { Wallet } from "lucide-react";
+import Image from "next/image";
+import { Wallet, LogOut } from "lucide-react";
+import { getProfile } from "@/lib/profiles";
+import { signOut } from "@/app/actions/auth";
 
-export default function Home() {
+export default async function Home() {
+  const profile = await getProfile();
+
+  if (profile) {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <div className="hero min-h-screen bg-base-200">
+          <div className="hero-content text-center">
+            <div className="max-w-md">
+              {profile.avatar_url ? (
+                <Image
+                  className="mx-auto mb-6 h-20 w-20 rounded-full object-cover"
+                  src={profile.avatar_url}
+                  alt="Profile"
+                  width={80}
+                  height={80}
+                />
+              ) : (
+                <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-primary text-3xl font-bold text-primary-content">
+                  {(profile.full_name ?? profile.email).charAt(0).toUpperCase()}
+                </div>
+              )}
+              <h1 className="text-3xl font-bold text-base-content">
+                Welcome, {profile.full_name ?? "friend"}!
+              </h1>
+              <p className="py-2 text-base-content/70">{profile.email}</p>
+              <p className="py-6 text-base-content/70">
+                Your AI-powered personal finance and budget planner. Track
+                income, expenses, and assets — coming soon.
+              </p>
+              <form action={signOut}>
+                <button className="btn btn-outline">
+                  <LogOut />
+                  Sign out
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="flex min-h-screen items-center justify-center">
       <div className="hero min-h-screen bg-base-200">
@@ -12,7 +57,9 @@ export default function Home() {
               Your AI-powered personal finance and budget planner. Track
               income, expenses, and assets — coming soon.
             </p>
-            <button className="btn btn-primary">Get Started</button>
+            <a href="/login" className="btn btn-primary">
+              Get Started
+            </a>
           </div>
         </div>
       </div>

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -30,3 +30,4 @@ Confirm the table columns exist, RLS is enabled, the policy is listed, and index
 | File | Applied? | Verified? |
 |------|----------|-----------|
 | `supabase/migrations/0001_transactions.sql` | Yes — applied via SQL Editor | Yes — table, columns, and RLS confirmed via PostgREST |
+| `supabase/migrations/0002_profiles.sql` | | |

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -31,3 +31,4 @@ Confirm the table columns exist, RLS is enabled, the policy is listed, and index
 |------|----------|-----------|
 | `supabase/migrations/0001_transactions.sql` | Yes — applied via SQL Editor | Yes — table, columns, and RLS confirmed via PostgREST |
 | `supabase/migrations/0002_profiles.sql` | | |
+| `supabase/migrations/0003_profiles_sync_update.sql` | | |

--- a/lib/profiles.ts
+++ b/lib/profiles.ts
@@ -1,0 +1,24 @@
+import { createClient } from "@/lib/supabase/server";
+
+export type Profile = {
+  id: string;
+  email: string;
+  full_name: string | null;
+  avatar_url: string | null;
+};
+
+export async function getProfile(): Promise<Profile | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, email, full_name, avatar_url")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  return profile ?? null;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "*.googleusercontent.com" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/supabase/migrations/0002_profiles.sql
+++ b/supabase/migrations/0002_profiles.sql
@@ -1,0 +1,67 @@
+-- Create Profiles Table
+CREATE TABLE IF NOT EXISTS public.profiles (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    full_name TEXT,
+    avatar_url TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Policies: Users can view & update only their own profile
+DROP POLICY IF EXISTS "Users can view their own profile" ON public.profiles;
+CREATE POLICY "Users can view their own profile"
+ON public.profiles
+FOR SELECT
+USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+CREATE POLICY "Users can update their own profile"
+ON public.profiles
+FOR UPDATE
+USING (auth.uid() = id)
+WITH CHECK (auth.uid() = id);
+
+-- Auto-create a profile row when a new auth user signs up
+-- Pulls name/avatar from the provider metadata (Google) or manual signup data.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    INSERT INTO public.profiles (id, email, full_name, avatar_url)
+    VALUES (
+        NEW.id,
+        COALESCE(NEW.email, NEW.raw_user_meta_data->>'email'),
+        COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.raw_user_meta_data->>'name'),
+        COALESCE(NEW.raw_user_meta_data->>'avatar_url', NEW.raw_user_meta_data->>'picture')
+    )
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name),
+        avatar_url = COALESCE(EXCLUDED.avatar_url, public.profiles.avatar_url),
+        updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+-- Backfill profiles for users created before this migration
+INSERT INTO public.profiles (id, email, full_name, avatar_url)
+SELECT
+    id,
+    COALESCE(email, raw_user_meta_data->>'email'),
+    COALESCE(raw_user_meta_data->>'full_name', raw_user_meta_data->>'name'),
+    COALESCE(raw_user_meta_data->>'avatar_url', raw_user_meta_data->>'picture')
+FROM auth.users
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/0003_profiles_sync_update.sql
+++ b/supabase/migrations/0003_profiles_sync_update.sql
@@ -1,0 +1,33 @@
+-- Sync profile when a user's email or metadata changes
+-- (e.g. a Google identity linked to an existing email/password account)
+CREATE OR REPLACE FUNCTION public.handle_user_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NEW.email IS DISTINCT FROM OLD.email
+       OR NEW.raw_user_meta_data IS DISTINCT FROM OLD.raw_user_meta_data THEN
+        INSERT INTO public.profiles (id, email, full_name, avatar_url)
+        VALUES (
+            NEW.id,
+            COALESCE(NEW.email, NEW.raw_user_meta_data->>'email'),
+            COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.raw_user_meta_data->>'name'),
+            COALESCE(NEW.raw_user_meta_data->>'avatar_url', NEW.raw_user_meta_data->>'picture')
+        )
+        ON CONFLICT (id) DO UPDATE SET
+            email = EXCLUDED.email,
+            full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name),
+            avatar_url = COALESCE(EXCLUDED.avatar_url, public.profiles.avatar_url),
+            updated_at = now();
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_updated ON auth.users;
+CREATE TRIGGER on_auth_user_updated
+AFTER UPDATE ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_user_update();


### PR DESCRIPTION
Implements sign-in with Google (OAuth) and email/password (with email verification), plus user profile capture.

Closes #4

## What's included
- Auth layout and login page with Google button + Sign in / Create account tabs
- OAuth callback route that exchanges the code for a session
- Email signup with first/last name fields (verification email via Resend SMTP)
- Friendly, actionable signup/signin error handling (existing account, unconfirmed email, weak password, resend button)
- `profiles` table + triggers that auto-create and keep profiles in sync with auth metadata (Google name/avatar)
- Signed-in landing page showing profile (avatar, name, email) with sign out
- README docs for OAuth, Resend SMTP, and migrations