### PR TITLE
feat: build dashboard summary cards

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { getUser } from "@/lib/supabase/server";
-import { computeSummary, getTransactions } from "@/lib/transactions";
+import { getTransactions } from "@/lib/transactions";
+import { computeSummary } from "@/lib/summary";
 import SummaryCards from "@/components/dashboard/SummaryCards";
 
 export default async function DashboardPage() {

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,14 +1,21 @@
 import { getUser } from "@/lib/supabase/server";
+import { computeSummary, getTransactions } from "@/lib/transactions";
+import SummaryCards from "@/components/dashboard/SummaryCards";
 
 export default async function DashboardPage() {
   const user = await getUser();
+  const transactions = await getTransactions();
+  const summary = computeSummary(transactions);
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
-      <h1 className="text-3xl font-bold text-base-content">Dashboard</h1>
-      <p className="text-base-content/70">
-        Signed in as {user?.email ?? "a BudgetIQ user"}
-      </p>
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 p-6">
+      <header>
+        <h1 className="text-3xl font-bold text-base-content">Dashboard</h1>
+        <p className="text-base-content/70">
+          Signed in as {user?.email ?? "a BudgetIQ user"}
+        </p>
+      </header>
+      <SummaryCards summary={summary} hasTransactions={transactions.length > 0} />
     </main>
   );
 }

--- a/components/dashboard/SummaryCards.tsx
+++ b/components/dashboard/SummaryCards.tsx
@@ -1,5 +1,5 @@
 import { Landmark, Receipt, Wallet } from "lucide-react";
-import type { Summary } from "@/lib/transactions";
+import type { Summary } from "@/lib/summary";
 
 const currency = new Intl.NumberFormat("en-US", {
   style: "currency",

--- a/components/dashboard/SummaryCards.tsx
+++ b/components/dashboard/SummaryCards.tsx
@@ -1,0 +1,58 @@
+import { Landmark, Receipt, Wallet } from "lucide-react";
+import type { Summary } from "@/lib/transactions";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+export default function SummaryCards({
+  summary,
+  hasTransactions,
+}: {
+  summary: Summary;
+  hasTransactions: boolean;
+}) {
+  return (
+    <section aria-label="Financial summary">
+      <div className="stats stats-vertical w-full shadow lg:stats-horizontal">
+        <div className="stat">
+          <div className="stat-figure text-primary">
+            <Wallet className="h-8 w-8" />
+          </div>
+          <div className="stat-title">Net Balance</div>
+          <div className="stat-value text-2xl">
+            {currency.format(summary.netBalance)}
+          </div>
+          <div className="stat-desc">Income + Assets − Expenses</div>
+        </div>
+        <div className="stat">
+          <div className="stat-figure text-secondary">
+            <Receipt className="h-8 w-8" />
+          </div>
+          <div className="stat-title">Monthly Spending</div>
+          <div className="stat-value text-2xl">
+            {currency.format(summary.monthlySpending)}
+          </div>
+          <div className="stat-desc">Expenses this calendar month</div>
+        </div>
+        <div className="stat">
+          <div className="stat-figure text-accent">
+            <Landmark className="h-8 w-8" />
+          </div>
+          <div className="stat-title">Total Assets</div>
+          <div className="stat-value text-2xl">
+            {currency.format(summary.totalAssets)}
+          </div>
+          <div className="stat-desc">Sum of asset accounts</div>
+        </div>
+      </div>
+      {!hasTransactions && (
+        <p className="mt-3 text-sm text-base-content/60">
+          No transactions yet — add your first one and your summary will update
+          live.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/lib/summary.ts
+++ b/lib/summary.ts
@@ -1,0 +1,37 @@
+import type { Transaction } from "@/types/transaction";
+
+export type Summary = {
+  netBalance: number;
+  monthlySpending: number;
+  totalAssets: number;
+};
+
+export function computeSummary(
+  transactions: Transaction[],
+  now: Date = new Date()
+): Summary {
+  let income = 0;
+  let expenses = 0;
+  let totalAssets = 0;
+  let monthlySpending = 0;
+
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  for (const t of transactions) {
+    if (t.type === "income") income += t.amount;
+    else if (t.type === "expense") {
+      expenses += t.amount;
+      const date = new Date(t.created_at);
+      if (date.getFullYear() === year && date.getMonth() === month) {
+        monthlySpending += t.amount;
+      }
+    } else if (t.type === "asset") totalAssets += t.amount;
+  }
+
+  return {
+    netBalance: income + totalAssets - expenses,
+    monthlySpending,
+    totalAssets,
+  };
+}

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -5,42 +5,6 @@ import type {
   TransactionType,
 } from "@/types/transaction";
 
-export type Summary = {
-  netBalance: number;
-  monthlySpending: number;
-  totalAssets: number;
-};
-
-export function computeSummary(
-  transactions: Transaction[],
-  now: Date = new Date()
-): Summary {
-  let income = 0;
-  let expenses = 0;
-  let totalAssets = 0;
-  let monthlySpending = 0;
-
-  const year = now.getFullYear();
-  const month = now.getMonth();
-
-  for (const t of transactions) {
-    if (t.type === "income") income += t.amount;
-    else if (t.type === "expense") {
-      expenses += t.amount;
-      const date = new Date(t.created_at);
-      if (date.getFullYear() === year && date.getMonth() === month) {
-        monthlySpending += t.amount;
-      }
-    } else if (t.type === "asset") totalAssets += t.amount;
-  }
-
-  return {
-    netBalance: income + totalAssets - expenses,
-    monthlySpending,
-    totalAssets,
-  };
-}
-
 type TransactionRow = {
   id: string;
   user_id: string;

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -5,6 +5,42 @@ import type {
   TransactionType,
 } from "@/types/transaction";
 
+export type Summary = {
+  netBalance: number;
+  monthlySpending: number;
+  totalAssets: number;
+};
+
+export function computeSummary(
+  transactions: Transaction[],
+  now: Date = new Date()
+): Summary {
+  let income = 0;
+  let expenses = 0;
+  let totalAssets = 0;
+  let monthlySpending = 0;
+
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  for (const t of transactions) {
+    if (t.type === "income") income += t.amount;
+    else if (t.type === "expense") {
+      expenses += t.amount;
+      const date = new Date(t.created_at);
+      if (date.getFullYear() === year && date.getMonth() === month) {
+        monthlySpending += t.amount;
+      }
+    } else if (t.type === "asset") totalAssets += t.amount;
+  }
+
+  return {
+    netBalance: income + totalAssets - expenses,
+    monthlySpending,
+    totalAssets,
+  };
+}
+
 type TransactionRow = {
   id: string;
   user_id: string;


### PR DESCRIPTION
Closes #7

Adds three live summary cards (Net Balance, Monthly Spending, Total Assets) to the dashboard, computed from the current user's transactions via a pure, unit-testable `computeSummary` helper in `lib/summary.ts`.

- Net Balance = income + assets − expenses
- Monthly Spending = expenses in the current calendar month (user's local time)
- Total Assets = sum of asset-type rows
- Empty state: zero values + hint when no transactions exist

Lint and `tsc --noEmit` pass; helper math verified against all acceptance criteria.