### PR TITLE
feat: build transaction table with add and delete

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { getTransactions } from "@/lib/transactions";
 import { computeSummary, groupExpensesByCategory } from "@/lib/summary";
 import SummaryCards from "@/components/dashboard/SummaryCards";
 import CategoryChart from "@/components/dashboard/CategoryChart";
+import TransactionTable from "@/components/dashboard/TransactionTable";
 
 export default async function DashboardPage() {
   const user = await getUser();
@@ -20,6 +21,7 @@ export default async function DashboardPage() {
       </header>
       <SummaryCards summary={summary} hasTransactions={transactions.length > 0} />
       <CategoryChart categories={categories} />
+      <TransactionTable transactions={transactions} />
     </main>
   );
 }

--- a/components/dashboard/AddTransactionModal.tsx
+++ b/components/dashboard/AddTransactionModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { Loader2, Plus } from "lucide-react";
+import { createTransaction } from "@/app/actions/transactions";
+import type { TransactionType } from "@/types/transaction";
+
+const TYPES: { value: TransactionType; label: string }[] = [
+  { value: "income", label: "Income" },
+  { value: "expense", label: "Expense" },
+  { value: "asset", label: "Asset" },
+];
+
+export default function AddTransactionModal() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function open() {
+    setError(null);
+    dialogRef.current?.showModal();
+  }
+
+  function close() {
+    dialogRef.current?.close();
+  }
+
+  function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      const result = await createTransaction({
+        type: formData.get("type") as TransactionType,
+        title: formData.get("title") as string,
+        amount: Number(formData.get("amount")),
+        category: (formData.get("category") as string) || undefined,
+      });
+      if (result.ok) {
+        close();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <>
+      <button className="btn btn-primary" onClick={open}>
+        <Plus />
+        Add transaction
+      </button>
+
+      <dialog ref={dialogRef} className="modal">
+        <div className="modal-box">
+          <h3 className="mb-4 text-lg font-bold">Add transaction</h3>
+          <form action={handleSubmit} className="flex flex-col gap-3">
+            <label className="form-control w-full">
+              <span className="label-text mb-1">Type</span>
+              <select className="select select-bordered w-full" name="type" defaultValue="expense" required>
+                {TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="form-control w-full">
+              <span className="label-text mb-1">Title</span>
+              <input
+                className="input input-bordered w-full"
+                type="text"
+                name="title"
+                placeholder="e.g. Groceries"
+                maxLength={255}
+                required
+              />
+            </label>
+            <label className="form-control w-full">
+              <span className="label-text mb-1">Amount</span>
+              <input
+                className="input input-bordered w-full"
+                type="number"
+                name="amount"
+                min="0.01"
+                step="0.01"
+                placeholder="0.00"
+                required
+              />
+            </label>
+            <label className="form-control w-full">
+              <span className="label-text mb-1">Category</span>
+              <input
+                className="input input-bordered w-full"
+                type="text"
+                name="category"
+                placeholder="e.g. Food, Rent, Salary"
+                maxLength={100}
+              />
+            </label>
+
+            {error && (
+              <div className="alert alert-error">
+                <span>{error}</span>
+              </div>
+            )}
+
+            <div className="modal-action">
+              <button
+                type="button"
+                className="btn"
+                onClick={close}
+                disabled={isPending}
+              >
+                Cancel
+              </button>
+              <button className="btn btn-primary" disabled={isPending}>
+                {isPending ? <Loader2 className="animate-spin" /> : null}
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
+    </>
+  );
+}

--- a/components/dashboard/TransactionTable.tsx
+++ b/components/dashboard/TransactionTable.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, Loader2, Trash2, X } from "lucide-react";
+import type { Transaction, TransactionType } from "@/types/transaction";
+import { deleteTransaction } from "@/app/actions/transactions";
+import AddTransactionModal from "@/components/dashboard/AddTransactionModal";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const TYPE_BADGES: Record<TransactionType, string> = {
+  income: "badge-success",
+  expense: "badge-error",
+  asset: "badge-info",
+};
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function TransactionTable({
+  transactions,
+}: {
+  transactions: Transaction[];
+}) {
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete(id: string) {
+    startTransition(async () => {
+      const result = await deleteTransaction(id);
+      if (!result.ok) {
+        setError(result.error);
+      }
+      setConfirmId(null);
+    });
+  }
+
+  return (
+    <div className="card w-full bg-base-100 shadow">
+      <div className="card-body">
+        <div className="flex items-center justify-between">
+          <h2 className="card-title">Transactions</h2>
+          <AddTransactionModal />
+        </div>
+
+        {error && (
+          <div className="alert alert-error">
+            <span>{error}</span>
+          </div>
+        )}
+
+        {transactions.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <p className="text-base-content/60">
+              No transactions yet. Add your first income, expense, or asset.
+            </p>
+            <AddTransactionModal />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="table table-zebra">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Category</th>
+                  <th>Type</th>
+                  <th>Amount</th>
+                  <th>Date</th>
+                  <th className="text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {transactions.map((t) => (
+                  <tr key={t.id}>
+                    <td className="font-medium">{t.title}</td>
+                    <td>{t.category}</td>
+                    <td>
+                      <span className={`badge ${TYPE_BADGES[t.type]}`}>
+                        {t.type}
+                      </span>
+                    </td>
+                    <td
+                      className={
+                        t.type === "expense"
+                          ? "font-semibold text-error"
+                          : t.type === "income"
+                            ? "font-semibold text-success"
+                            : "font-semibold"
+                      }
+                    >
+                      {currency.format(t.amount)}
+                    </td>
+                    <td className="whitespace-nowrap text-base-content/70">
+                      {formatDate(t.created_at)}
+                    </td>
+                    <td className="text-right">
+                      {confirmId === t.id ? (
+                        <div className="flex justify-end gap-2">
+                          <span className="text-sm text-base-content/70">
+                            Delete?
+                          </span>
+                          <button
+                            className="btn btn-error btn-xs"
+                            onClick={() => handleDelete(t.id)}
+                            disabled={isPending}
+                            aria-label={`Confirm delete of ${t.title}`}
+                          >
+                            {isPending ? (
+                              <Loader2 className="animate-spin" />
+                            ) : (
+                              <Check />
+                            )}
+                            Yes
+                          </button>
+                          <button
+                            className="btn btn-ghost btn-xs"
+                            onClick={() => setConfirmId(null)}
+                            disabled={isPending}
+                            aria-label="Cancel delete"
+                          >
+                            <X />
+                            No
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          className="btn btn-ghost btn-sm text-error"
+                          onClick={() => {
+                            setConfirmId(t.id);
+                            setError(null);
+                          }}
+                          aria-label={`Delete ${t.title}`}
+                        >
+                          <Trash2 />
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #9

Adds a DaisyUI transaction table to the dashboard with add and delete flows backed by the existing server actions (`createTransaction` / `deleteTransaction`), so rows appear/disappear without a full reload.

- Table: title, category, type badge, amount, local date, newest first
- Add modal: type select, title, amount, category; pending state; inline errors; closes on success
- Delete: inline Yes/No confirmation per row
- Empty state with call-to-action to add a transaction
- Summary cards and category chart update automatically after add/delete (shared data layer + `revalidatePath`)

Lint and `tsc --noEmit` pass.