### PR TITLE
feat: build AI chatbot drawer with add-transaction action

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { computeSummary, groupExpensesByCategory } from "@/lib/summary";
 import SummaryCards from "@/components/dashboard/SummaryCards";
 import CategoryChart from "@/components/dashboard/CategoryChart";
 import TransactionTable from "@/components/dashboard/TransactionTable";
+import ChatDrawer from "@/components/ai/ChatDrawer";
 
 export default async function DashboardPage() {
   const user = await getUser();
@@ -12,16 +13,21 @@ export default async function DashboardPage() {
   const categories = groupExpensesByCategory(transactions);
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 p-6">
-      <header>
-        <h1 className="text-3xl font-bold text-base-content">Dashboard</h1>
-        <p className="text-base-content/70">
-          Signed in as {user?.email ?? "a BudgetIQ user"}
-        </p>
-      </header>
-      <SummaryCards summary={summary} hasTransactions={transactions.length > 0} />
-      <CategoryChart categories={categories} />
-      <TransactionTable transactions={transactions} />
-    </main>
+    <ChatDrawer>
+      <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 p-6">
+        <header>
+          <h1 className="text-3xl font-bold text-base-content">Dashboard</h1>
+          <p className="text-base-content/70">
+            Signed in as {user?.email ?? "a BudgetIQ user"}
+          </p>
+        </header>
+        <SummaryCards
+          summary={summary}
+          hasTransactions={transactions.length > 0}
+        />
+        <CategoryChart categories={categories} />
+        <TransactionTable transactions={transactions} />
+      </main>
+    </ChatDrawer>
   );
 }

--- a/components/ai/ChatDrawer.tsx
+++ b/components/ai/ChatDrawer.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Bot, Loader2, Send, X } from "lucide-react";
+import type { ChatActionResponse, ParsedTransactionAction } from "@/lib/gemini";
+import MessageBubble from "@/components/ai/MessageBubble";
+
+type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  action?: ParsedTransactionAction;
+  error?: boolean;
+};
+
+export default function ChatDrawer({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isPending, setIsPending] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({
+      top: listRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages, isPending]);
+
+  async function handleSend() {
+    const text = input.trim();
+    if (!text || isPending) return;
+
+    setInput("");
+    setMessages((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), role: "user", text },
+    ]);
+    setIsPending(true);
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text }),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(
+          (body as { error?: string } | null)?.error ??
+            `Request failed (${response.status})`
+        );
+      }
+
+      const data = (await response.json()) as ChatActionResponse;
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          text: data.message,
+          action: data.hasAction ? data.transaction : undefined,
+        },
+      ]);
+    } catch (error) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          text:
+            error instanceof Error
+              ? error.message
+              : "Something went wrong. Please try again.",
+          error: true,
+        },
+      ]);
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <div className="drawer drawer-end">
+      <input id="chat-drawer" type="checkbox" className="drawer-toggle" />
+      <div className="drawer-content">
+        {children}
+        <label
+          htmlFor="chat-drawer"
+          className="btn btn-primary btn-circle fixed bottom-6 right-6 z-40 shadow-lg"
+          aria-label="Open AI assistant"
+        >
+          <Bot />
+        </label>
+      </div>
+      <div className="drawer-side z-50">
+        <label
+          htmlFor="chat-drawer"
+          aria-label="Close AI assistant"
+          className="drawer-overlay"
+        />
+        <div className="flex h-full w-80 max-w-[85vw] flex-col bg-base-100">
+          <div className="flex items-center justify-between border-b border-base-200 p-4">
+            <div className="flex items-center gap-2">
+              <Bot className="h-5 w-5 text-primary" />
+              <h2 className="font-bold">BudgetIQ Assistant</h2>
+            </div>
+            <label
+              htmlFor="chat-drawer"
+              className="btn btn-ghost btn-sm"
+              aria-label="Close assistant"
+            >
+              <X />
+            </label>
+          </div>
+
+          <div ref={listRef} className="flex-1 space-y-3 overflow-y-auto p-4">
+            {messages.length === 0 && (
+              <p className="pt-10 text-center text-sm text-base-content/60">
+                Ask me anything about your finances.
+                <br />
+                Try: &ldquo;I spent $15 on coffee&rdquo;
+              </p>
+            )}
+            {messages.map((m) => (
+              <MessageBubble
+                key={m.id}
+                role={m.role}
+                text={m.text}
+                action={m.action}
+                error={m.error}
+              />
+            ))}
+            {isPending && (
+              <div className="chat chat-start">
+                <div className="chat-bubble chat-bubble-secondary">
+                  <Loader2 className="inline h-4 w-4 animate-spin" />
+                  Thinking…
+                </div>
+              </div>
+            )}
+          </div>
+
+          <form
+            className="flex gap-2 border-t border-base-200 p-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSend();
+            }}
+          >
+            <input
+              className="input input-bordered flex-1"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Ask your assistant…"
+              aria-label="Chat message"
+              disabled={isPending}
+            />
+            <button
+              className="btn btn-primary"
+              type="submit"
+              disabled={isPending || input.trim().length === 0}
+              aria-label="Send message"
+            >
+              {isPending ? <Loader2 className="animate-spin" /> : <Send />}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ai/MessageBubble.tsx
+++ b/components/ai/MessageBubble.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ParsedTransactionAction } from "@/lib/gemini";
+import TransactionActionCard from "@/components/ai/TransactionActionCard";
+
+export default function MessageBubble({
+  role,
+  text,
+  action,
+  error,
+}: {
+  role: "user" | "assistant";
+  text: string;
+  action?: ParsedTransactionAction;
+  error?: boolean;
+}) {
+  if (role === "user") {
+    return (
+      <div className="chat chat-end">
+        <div className="chat-bubble chat-bubble-primary">{text}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chat chat-start">
+      <div
+        className={`chat-bubble ${
+          error ? "chat-bubble-error" : "chat-bubble-secondary"
+        }`}
+      >
+        {text}
+      </div>
+      {action && <TransactionActionCard action={action} />}
+    </div>
+  );
+}

--- a/components/ai/TransactionActionCard.tsx
+++ b/components/ai/TransactionActionCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { Check, Loader2, Plus } from "lucide-react";
+import type { ParsedTransactionAction } from "@/lib/gemini";
+import { createTransaction } from "@/app/actions/transactions";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const TYPE_LABELS: Record<ParsedTransactionAction["type"], string> = {
+  income: "Add Income",
+  expense: "Add Expense",
+  asset: "Add Asset",
+};
+
+export default function TransactionActionCard({
+  action,
+}: {
+  action: ParsedTransactionAction;
+}) {
+  const idRef = useRef<string>(crypto.randomUUID());
+  const [status, setStatus] = useState<"idle" | "added" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleAdd() {
+    setError(null);
+    startTransition(async () => {
+      const result = await createTransaction({
+        type: action.type,
+        title: action.title,
+        amount: action.amount,
+        category: action.category,
+        id: idRef.current,
+      });
+      if (result.ok) {
+        setStatus("added");
+      } else {
+        setStatus("error");
+        setError(result.error);
+      }
+    });
+  }
+
+  if (status === "added") {
+    return (
+      <div className="alert alert-success mt-2 max-w-xs">
+        <Check />
+        <span>
+          Added {action.title} ({currency.format(action.amount)})
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card mt-2 max-w-xs border border-base-300 bg-base-100">
+      <div className="card-body gap-2 p-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+          Detected transaction
+        </p>
+        <p className="font-medium">
+          {action.title} — {currency.format(action.amount)}
+        </p>
+        {action.category && (
+          <p className="text-xs text-base-content/60">
+            Category: {action.category} · Type: {action.type}
+          </p>
+        )}
+        {error && (
+          <p className="text-xs text-error" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={handleAdd}
+          disabled={isPending}
+        >
+          {isPending ? <Loader2 className="animate-spin" /> : <Plus />}
+          {TYPE_LABELS[action.type]}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #11

Adds an AI chatbot drawer to the dashboard that lets users chat with Gemini and one-click save detected transactions.

**Components**
- `ChatDrawer` — DaisyUI drawer (opens from a floating bot button) with message list, input, pending state, and auto-scroll
- `MessageBubble` — user/assistant DaisyUI chat bubbles (error variant too)
- `TransactionActionCard` — rendered when the API returns `hasAction: true`, with an Add button per type (Add Income/Expense/Asset), success confirmation, and inline errors

**Key behaviors**
- End-to-end: type "I spent \ on coffee" → detected card → one click saves via the existing `createTransaction` server action and the dashboard table/summary update immediately
- Idempotent adds: each card holds a fixed `crypto.randomUUID()` reused on retry (server upserts on id), plus the button is disabled while pending — no duplicates on double-click
- Plain chat messages render no action card
- Session-protected via `/api/chat`

Lint and `tsc --noEmit` pass; manually verified end-to-end in the browser.