### PR TITLE
feat: add daily financial quote and display

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,3 +7,6 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
 
 # Google Gemini API Key (aistudio.google.com)
 GEMINI_API_KEY=your-gemini-api-key
+
+# API Ninjas Quotes API Key (api-ninjas.com)
+API_NINJAS_API_KEY=your-api-ninjas-api-key

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { getUser } from "@/lib/supabase/server";
 import { getTransactions } from "@/lib/transactions";
 import { computeSummary, groupExpensesByCategory } from "@/lib/summary";
-import { quoteForDate } from "@/lib/quotes";
+import { getDailyQuote } from "@/lib/quotes";
 import SummaryCards from "@/components/dashboard/SummaryCards";
 import CategoryChart from "@/components/dashboard/CategoryChart";
 import TransactionTable from "@/components/dashboard/TransactionTable";
@@ -13,7 +13,7 @@ export default async function DashboardPage() {
   const transactions = await getTransactions();
   const summary = computeSummary(transactions);
   const categories = groupExpensesByCategory(transactions);
-  const quote = quoteForDate();
+  const quote = await getDailyQuote();
 
   return (
     <ChatDrawer>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,9 +1,11 @@
 import { getUser } from "@/lib/supabase/server";
 import { getTransactions } from "@/lib/transactions";
 import { computeSummary, groupExpensesByCategory } from "@/lib/summary";
+import { quoteForDate } from "@/lib/quotes";
 import SummaryCards from "@/components/dashboard/SummaryCards";
 import CategoryChart from "@/components/dashboard/CategoryChart";
 import TransactionTable from "@/components/dashboard/TransactionTable";
+import QuoteCard from "@/components/dashboard/QuoteCard";
 import ChatDrawer from "@/components/ai/ChatDrawer";
 
 export default async function DashboardPage() {
@@ -11,6 +13,7 @@ export default async function DashboardPage() {
   const transactions = await getTransactions();
   const summary = computeSummary(transactions);
   const categories = groupExpensesByCategory(transactions);
+  const quote = quoteForDate();
 
   return (
     <ChatDrawer>
@@ -21,6 +24,7 @@ export default async function DashboardPage() {
             Signed in as {user?.email ?? "a BudgetIQ user"}
           </p>
         </header>
+        <QuoteCard quote={quote} />
         <SummaryCards
           summary={summary}
           hasTransactions={transactions.length > 0}

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { quoteForDate } from "@/lib/quotes";
+
+export const runtime = "nodejs";
+
+export const revalidate = 86_400;
+
+export function GET() {
+  return NextResponse.json(quoteForDate());
+}

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
-import { quoteForDate } from "@/lib/quotes";
+import { getDailyQuote } from "@/lib/quotes";
 
 export const runtime = "nodejs";
 
-export const revalidate = 86_400;
+export const dynamic = "force-dynamic";
 
-export function GET() {
-  return NextResponse.json(quoteForDate());
+export async function GET() {
+  const quote = await getDailyQuote();
+  return NextResponse.json(quote);
 }

--- a/components/dashboard/QuoteCard.tsx
+++ b/components/dashboard/QuoteCard.tsx
@@ -1,0 +1,20 @@
+import { Quote } from "lucide-react";
+import type { Quote as QuoteType } from "@/lib/quotes";
+
+export default function QuoteCard({ quote }: { quote: QuoteType }) {
+  return (
+    <figure className="card w-full bg-base-100 shadow">
+      <div className="card-body flex-row items-start gap-3">
+        <Quote className="mt-1 h-6 w-6 shrink-0 text-primary" aria-hidden />
+        <blockquote>
+          <p className="text-base font-medium text-base-content">
+            &ldquo;{quote.text}&rdquo;
+          </p>
+          <figcaption className="mt-1 text-sm text-base-content/60">
+            — {quote.author}
+          </figcaption>
+        </blockquote>
+      </div>
+    </figure>
+  );
+}

--- a/lib/quotes.ts
+++ b/lib/quotes.ts
@@ -61,24 +61,34 @@ export function quoteForDate(date: Date = new Date()): Quote {
   return QUOTES[index];
 }
 
-type QuoteSource = (data: Record<string, unknown>) => Quote | null;
+type QuoteSource = (data: unknown) => Quote | null;
+
+function parseQuoteRecord(record: Record<string, unknown>): Quote | null {
+  const text = typeof record.content === "string" ? record.content.trim() : "";
+  const author =
+    typeof record.author === "string" ? record.author.trim() : "Unknown";
+  return text ? { text, author } : null;
+}
 
 const SOURCES: { url: string; parse: QuoteSource }[] = [
   {
-    url: "https://api.quotable.io/random?tags=business",
+    url: "https://api.quotable.io/quotes/random?tags=business",
     parse: (data) => {
-      const text = typeof data.content === "string" ? data.content.trim() : "";
-      const author =
-        typeof data.author === "string" ? data.author.trim() : "Unknown";
-      return text ? { text, author } : null;
+      if (Array.isArray(data)) return parseQuoteRecord(data[0] ?? {});
+      if (typeof data === "object" && data !== null) {
+        return parseQuoteRecord(data as Record<string, unknown>);
+      }
+      return null;
     },
   },
   {
     url: "https://dummyjson.com/quotes/random",
     parse: (data) => {
-      const text = typeof data.quote === "string" ? data.quote.trim() : "";
+      if (typeof data !== "object" || data === null) return null;
+      const record = data as Record<string, unknown>;
+      const text = typeof record.quote === "string" ? record.quote.trim() : "";
       const author =
-        typeof data.author === "string" ? data.author.trim() : "Unknown";
+        typeof record.author === "string" ? record.author.trim() : "Unknown";
       return text ? { text, author } : null;
     },
   },
@@ -93,8 +103,7 @@ async function fetchRandomQuote(): Promise<Quote> {
       });
       if (!response.ok) continue;
       const data: unknown = await response.json();
-      if (typeof data !== "object" || data === null) continue;
-      const quote = source.parse(data as Record<string, unknown>);
+      const quote = source.parse(data);
       if (quote) return quote;
     } catch {
       // try the next source

--- a/lib/quotes.ts
+++ b/lib/quotes.ts
@@ -70,7 +70,24 @@ function parseQuoteRecord(record: Record<string, unknown>): Quote | null {
   return text ? { text, author } : null;
 }
 
-const SOURCES: { url: string; parse: QuoteSource }[] = [
+function parseQuoteOfDay(data: unknown): Quote | null {
+  if (Array.isArray(data)) {
+    const record = data[0];
+    if (typeof record !== "object" || record === null) return null;
+    const r = record as Record<string, unknown>;
+    const text = typeof r.quote === "string" ? r.quote.trim() : "";
+    const author = typeof r.author === "string" ? r.author.trim() : "Unknown";
+    return text ? { text, author } : null;
+  }
+  return null;
+}
+
+const SOURCES: { url: string; headers?: Record<string, string>; parse: QuoteSource }[] = [
+  {
+    url: "https://api.api-ninjas.com/v2/quoteoftheday",
+    headers: { "X-Api-Key": process.env.API_NINJAS_API_KEY ?? "" },
+    parse: parseQuoteOfDay,
+  },
   {
     url: "https://api.quotable.io/quotes/random?tags=business",
     parse: (data) => {
@@ -100,6 +117,10 @@ async function fetchRandomQuote(): Promise<Quote> {
       const response = await fetch(source.url, {
         cache: "no-store",
         signal: AbortSignal.timeout(5_000),
+        headers: {
+          "Content-Type": "application/json",
+          ...(source.headers ?? {}),
+        },
       });
       if (!response.ok) continue;
       const data: unknown = await response.json();

--- a/lib/quotes.ts
+++ b/lib/quotes.ts
@@ -1,0 +1,82 @@
+export type Quote = {
+  text: string;
+  author: string;
+};
+
+const QUOTES: Quote[] = [
+  {
+    text: "Do not save what is left after spending, but spend what is left after saving.",
+    author: "Warren Buffett",
+  },
+  {
+    text: "The habit of saving is itself an education; it fosters every virtue, teaches self-denial, cultivates the sense of order, and trains to forethought.",
+    author: "Margaret Oliphant",
+  },
+  {
+    text: "Financial freedom is available to those who learn about it and work for it.",
+    author: "Robert Kiyosaki",
+  },
+  {
+    text: "Formal education will make you a living; self-education will make you a fortune.",
+    author: "Jim Rohn",
+  },
+  {
+    text: "A budget is telling your money where to go instead of wondering where it went.",
+    author: "John C. Maxwell",
+  },
+  {
+    text: "It is not how much money you make, but how much money you keep.",
+    author: "Robert Kiyosaki",
+  },
+  {
+    text: "Beware of little expenses; a small leak will sink a great ship.",
+    author: "Benjamin Franklin",
+  },
+  {
+    text: "An investment in knowledge pays the best interest.",
+    author: "Benjamin Franklin",
+  },
+  {
+    text: "Don't look for the needle in the haystack. Just buy the haystack!",
+    author: "John Bogle",
+  },
+  {
+    text: "The stock market is a device for transferring money from the impatient to the patient.",
+    author: "Warren Buffett",
+  },
+  {
+    text: "Every time you borrow money, you're robbing your future self.",
+    author: "Nathan W. Morris",
+  },
+  {
+    text: "Wealth is not about having a lot of money; it's about having a lot of options.",
+    author: "Chris Rock",
+  },
+  {
+    text: "Saving money is a great habit to have, but investing money is a great way to grow it.",
+    author: "Unknown",
+  },
+  {
+    text: "The best way to predict the future is to create it.",
+    author: "Peter Drucker",
+  },
+];
+
+function dayOfYear(date: Date): number {
+  const start = Date.UTC(date.getUTCFullYear(), 0, 1);
+  const day = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate()
+  );
+  return Math.floor((day - start) / 86_400_000) + 1;
+}
+
+export function quoteForDate(date: Date = new Date()): Quote {
+  const index = (dayOfYear(date) - 1) % QUOTES.length;
+  return QUOTES[index];
+}
+
+export function listQuotes(): Quote[] {
+  return QUOTES;
+}

--- a/lib/quotes.ts
+++ b/lib/quotes.ts
@@ -9,16 +9,8 @@ const QUOTES: Quote[] = [
     author: "Warren Buffett",
   },
   {
-    text: "The habit of saving is itself an education; it fosters every virtue, teaches self-denial, cultivates the sense of order, and trains to forethought.",
-    author: "Margaret Oliphant",
-  },
-  {
     text: "Financial freedom is available to those who learn about it and work for it.",
     author: "Robert Kiyosaki",
-  },
-  {
-    text: "Formal education will make you a living; self-education will make you a fortune.",
-    author: "Jim Rohn",
   },
   {
     text: "A budget is telling your money where to go instead of wondering where it went.",
@@ -37,10 +29,6 @@ const QUOTES: Quote[] = [
     author: "Benjamin Franklin",
   },
   {
-    text: "Don't look for the needle in the haystack. Just buy the haystack!",
-    author: "John Bogle",
-  },
-  {
     text: "The stock market is a device for transferring money from the impatient to the patient.",
     author: "Warren Buffett",
   },
@@ -51,10 +39,6 @@ const QUOTES: Quote[] = [
   {
     text: "Wealth is not about having a lot of money; it's about having a lot of options.",
     author: "Chris Rock",
-  },
-  {
-    text: "Saving money is a great habit to have, but investing money is a great way to grow it.",
-    author: "Unknown",
   },
   {
     text: "The best way to predict the future is to create it.",
@@ -77,6 +61,56 @@ export function quoteForDate(date: Date = new Date()): Quote {
   return QUOTES[index];
 }
 
-export function listQuotes(): Quote[] {
-  return QUOTES;
+type QuoteSource = (data: Record<string, unknown>) => Quote | null;
+
+const SOURCES: { url: string; parse: QuoteSource }[] = [
+  {
+    url: "https://api.quotable.io/random?tags=business",
+    parse: (data) => {
+      const text = typeof data.content === "string" ? data.content.trim() : "";
+      const author =
+        typeof data.author === "string" ? data.author.trim() : "Unknown";
+      return text ? { text, author } : null;
+    },
+  },
+  {
+    url: "https://dummyjson.com/quotes/random",
+    parse: (data) => {
+      const text = typeof data.quote === "string" ? data.quote.trim() : "";
+      const author =
+        typeof data.author === "string" ? data.author.trim() : "Unknown";
+      return text ? { text, author } : null;
+    },
+  },
+];
+
+async function fetchRandomQuote(): Promise<Quote> {
+  for (const source of SOURCES) {
+    try {
+      const response = await fetch(source.url, {
+        cache: "no-store",
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!response.ok) continue;
+      const data: unknown = await response.json();
+      if (typeof data !== "object" || data === null) continue;
+      const quote = source.parse(data as Record<string, unknown>);
+      if (quote) return quote;
+    } catch {
+      // try the next source
+    }
+  }
+  throw new Error("No quote source available");
+}
+
+const dailyCache = new Map<string, Quote>();
+
+export async function getDailyQuote(now: Date = new Date()): Promise<Quote> {
+  const key = now.toISOString().slice(0, 10);
+  const cached = dailyCache.get(key);
+  if (cached) return cached;
+
+  const quote = await fetchRandomQuote().catch(() => quoteForDate(now));
+  dailyCache.set(key, quote);
+  return quote;
 }


### PR DESCRIPTION
Closes #12

Adds a daily financial quote to the dashboard plus a `GET /api/quotes` endpoint.

**Source chain** (`lib/quotes.ts`)
1. **API Ninjas `/v2/quoteoftheday`** (primary) — same pre-vetted quote all day, changes daily; key from `API_NINJAS_API_KEY` (server-side only, gitignored, documented in `.env.local.example`)
2. Quotable `/quotes/random` — fallback
3. DummyJSON `/quotes/random` — fallback
4. Static list — safety net (also drives deterministic `quoteForDate`)

**Behavior**
- Quote fetched once per UTC day then cached in memory → deterministic within the day, new quote at UTC midnight
- 5s timeout per source so the dashboard never hangs
- `QuoteCard` on the dashboard shows text + author (server-rendered)
- `/api/quotes` returns the same quote as JSON

**Verified live**: API Ninjas quote served, deterministic across calls; picker unit-tested; lint + `tsc --noEmit` pass.