### PR TITLE
fix: show friendly error for failed auth requests instead of {}

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -158,14 +158,20 @@ export default function LoginPage() {
         );
       }
     } else {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
       if (error) {
         applyError(error);
-      } else {
+      } else if (data.session) {
         window.location.href = "/dashboard";
+      } else {
+        applyError({
+          code: "invalid_credentials",
+          message:
+            "We couldn't sign you in. Your email may not be confirmed yet — check your inbox (and spam) for the confirmation link.",
+        });
       }
     }
 

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -9,14 +9,22 @@ import { Loader2, Globe, Mail, Send } from "lucide-react";
 type Mode = "signin" | "signup";
 type ErrorAction = "switchToSignIn" | "switchToSignUp" | "resend" | null;
 
-type AuthError = { code?: string; message?: string } | null;
+type AuthError = { code?: string; message?: string; status?: number } | null;
 
 function friendlyError(
   error: AuthError
 ): { message: string; action: ErrorAction } {
   const code = error?.code ?? "";
   const message = error?.message ?? "";
+  const status = error?.status ?? 0;
   const lower = message.toLowerCase();
+
+  if (status >= 500 || message === "{}" || message.trim() === "") {
+    return {
+      message: "Something went wrong on our end. Please try again in a moment.",
+      action: null,
+    };
+  }
 
   if (code === "user_already_exists" || lower.includes("already registered")) {
     return {


### PR DESCRIPTION
Closes #29