### PR TITLE
T2: move navbar into auth and dashboard layouts

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,11 +1,16 @@
+import Navbar from "@/components/Navbar";
+
 export default function AuthLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-base-200 p-4">
-      <div className="w-full max-w-md">{children}</div>
-    </main>
+    <>
+      <Navbar />
+      <main className="flex min-h-screen items-center justify-center bg-base-200 p-4">
+        <div className="w-full max-w-md">{children}</div>
+      </main>
+    </>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getUser } from "@/lib/supabase/server";
+import Navbar from "@/components/Navbar";
 
 export default async function DashboardLayout({
   children,
@@ -9,5 +10,10 @@ export default async function DashboardLayout({
   const user = await getUser();
   if (!user) redirect("/login");
 
-  return <div className="min-h-screen bg-base-200">{children}</div>;
+  return (
+    <div className="min-h-screen bg-base-200">
+      <Navbar />
+      {children}
+    </div>
+  );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -11,9 +11,9 @@ export default async function DashboardLayout({
   if (!user) redirect("/login");
 
   return (
-    <div className="min-h-screen bg-base-200">
+    <>
       <Navbar />
-      {children}
-    </div>
+      <div className="min-h-screen bg-base-200">{children}</div>
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { cookies } from "next/headers";
 import "./globals.css";
-import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,10 +35,7 @@ export default async function RootLayout({
       suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable}`}
     >
-      <body>
-        <Navbar />
-        {children}
-      </body>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
Closes #36

Moves the global navbar out of the root layout into the auth and dashboard layouts:
- Login and dashboard pages keep the exact same navbar, now as a direct body child (identical DOM order to before).
- The anonymous landing page (`/`) no longer renders the global navbar, leaving it free for its own landing nav (issue #34).
- Verified: `/` renders without the navbar header; `/login` renders with it; `next build` passes.