### PR TITLE
T4 — Landing nav + hero with stylized product mockup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getProfile } from "@/lib/profiles";
 import { landingView } from "@/lib/landing-view";
+import LandingNav from "@/components/landing/LandingNav";
 import LandingHero from "@/components/landing/LandingHero";
 
 export default async function Home() {
@@ -11,8 +12,11 @@ export default async function Home() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <LandingHero />
-    </main>
+    <div className="min-h-screen bg-base-200">
+      <LandingNav />
+      <main>
+        <LandingHero />
+      </main>
+    </div>
   );
 }

--- a/components/landing/HeroMockup.tsx
+++ b/components/landing/HeroMockup.tsx
@@ -1,0 +1,95 @@
+type Trend = "up" | "down";
+
+interface SummaryCardData {
+  label: string;
+  value: string;
+  delta: string;
+  trend: Trend;
+}
+
+const summaryCards: SummaryCardData[] = [
+  { label: "Net Balance", value: "$12,450", delta: "+$1,250", trend: "up" },
+  { label: "Monthly Spend", value: "$3,180", delta: "-12%", trend: "down" },
+  { label: "Total Assets", value: "$86,200", delta: "+4.2%", trend: "up" },
+];
+
+function SummaryCard({ label, value, delta, trend }: SummaryCardData) {
+  return (
+    <div className="rounded-xl border border-base-300/60 bg-base-200/60 p-3">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-base-content/60">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-bold sm:text-base">{value}</p>
+      <p
+        className={`mt-0.5 text-[10px] font-medium ${
+          trend === "up" ? "text-primary" : "text-base-content/50"
+        }`}
+      >
+        {delta}
+      </p>
+    </div>
+  );
+}
+
+function DonutChart() {
+  return (
+    <div
+      className="relative h-32 w-32 shrink-0"
+      role="img"
+      aria-label="Net balance breakdown"
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background:
+            "conic-gradient(var(--color-primary) 0% 42%, var(--color-base-content) 42% 58%, var(--color-base-300) 58% 100%)",
+        }}
+      />
+      <div className="absolute inset-[24%] flex flex-col items-center justify-center rounded-full bg-base-100">
+        <p className="text-sm font-bold">$1,250</p>
+        <p className="text-[10px] text-base-content/60">saved</p>
+      </div>
+    </div>
+  );
+}
+
+export default function HeroMockup() {
+  return (
+    <div className="mx-auto w-full max-w-md rounded-2xl border border-base-300/60 bg-base-100 p-6 shadow-xl">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex gap-1.5">
+          <span className="h-3 w-3 rounded-full bg-error/70" aria-hidden="true" />
+          <span
+            className="h-3 w-3 rounded-full bg-warning/70"
+            aria-hidden="true"
+          />
+          <span
+            className="h-3 w-3 rounded-full bg-success/70"
+            aria-hidden="true"
+          />
+        </div>
+        <p className="text-xs font-medium text-base-content/60">
+          BudgetIQ dashboard
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {summaryCards.map((card) => (
+          <SummaryCard key={card.label} {...card} />
+        ))}
+      </div>
+
+      <div className="mt-6 flex items-center gap-4">
+        <DonutChart />
+        <div className="flex flex-1 flex-col gap-2">
+          <div className="max-w-[85%] self-start rounded-2xl rounded-bl-sm bg-base-200 px-4 py-2 text-sm text-base-content">
+            I spent $15 on coffee
+          </div>
+          <div className="max-w-[85%] self-end rounded-2xl rounded-br-sm bg-primary px-4 py-2 text-sm font-medium text-primary-content">
+            Logged ✓
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/landing/LandingHero.test.tsx
+++ b/components/landing/LandingHero.test.tsx
@@ -1,39 +1,35 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import LandingHero from "@/components/landing/LandingHero";
 
-vi.mock("next/image", () => ({
-  default: ({
-    src,
-    alt,
-    className,
-    width,
-    height,
-  }: {
-    src: string;
-    alt: string;
-    className?: string;
-    width?: number;
-    height?: number;
-  }) => (
-    // eslint-disable-next-line @next/next/no-img-element -- plain img stands in for next/image in jsdom
-    <img
-      src={src}
-      alt={alt}
-      className={className}
-      width={width}
-      height={height}
-    />
-  ),
-}));
-
 describe("LandingHero", () => {
-  it("renders the value proposition and call-to-action", () => {
+  it("renders the headline, both call-to-actions, and trust strip", () => {
     render(<LandingHero />);
 
     expect(
-      screen.getByText(/track income, expenses, and assets/i)
+      screen.getByRole("heading", {
+        level: 1,
+        name: /your money, finally under control/i,
+      })
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Get Started" })).toBeInTheDocument();
+
+    const getStarted = screen.getByRole("link", {
+      name: /get started free/i,
+    });
+    expect(getStarted).toBeInTheDocument();
+    expect(getStarted).toHaveAttribute("href", "/login");
+
+    const viewOnGithub = screen.getByRole("link", {
+      name: /view on github/i,
+    });
+    expect(viewOnGithub).toBeInTheDocument();
+    expect(viewOnGithub).toHaveAttribute(
+      "href",
+      "https://github.com/AmineMabrouk17/BudgetIQ"
+    );
+
+    expect(
+      screen.getByText(/free forever · open source · no ads · your data, yours/i)
+    ).toBeInTheDocument();
   });
 });

--- a/components/landing/LandingHero.tsx
+++ b/components/landing/LandingHero.tsx
@@ -1,27 +1,34 @@
-import Image from "next/image";
+import Link from "next/link";
+import HeroMockup from "@/components/landing/HeroMockup";
 
 export default function LandingHero() {
   return (
-    <div className="hero min-h-screen bg-base-200">
-      <div className="hero-content text-center">
-        <div className="max-w-md">
-          <Image
-            src="/logo-vertical-light.png"
-            alt="BudgetIQ logo"
-            width={320}
-            height={320}
-            priority
-            className="mx-auto mb-6 h-auto w-full max-w-xs"
-          />
-          <p className="py-6 text-base-content/70">
-            Your AI-powered personal finance app. Track income, expenses, and
-            assets.
-          </p>
-          <a href="/login" className="btn btn-primary">
-            Get Started
+    <section className="mx-auto grid w-full max-w-6xl items-center gap-12 px-6 pb-20 pt-12 lg:grid-cols-2 lg:pb-24 lg:pt-16">
+      <div>
+        <h1 className="text-4xl font-bold leading-tight tracking-tight sm:text-5xl">
+          Your money, finally under control.
+        </h1>
+        <p className="mt-6 max-w-xl text-lg leading-relaxed text-base-content/70">
+          BudgetIQ is a free, open-source personal finance app. Track income,
+          expenses, and assets — and let the AI assistant log them straight
+          from your words. Sign in with Google in seconds.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <Link href="/login" className="btn btn-primary btn-lg">
+            Get started free
+          </Link>
+          <a
+            href="https://github.com/AmineMabrouk17/BudgetIQ"
+            className="btn btn-outline btn-lg"
+          >
+            View on GitHub
           </a>
         </div>
+        <p className="mt-10 text-sm font-medium tracking-wide text-base-content/60">
+          Free forever · Open source · No ads · Your data, yours
+        </p>
       </div>
-    </div>
+      <HeroMockup />
+    </section>
   );
 }

--- a/components/landing/LandingNav.test.tsx
+++ b/components/landing/LandingNav.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import LandingNav from "@/components/landing/LandingNav";
+
+describe("LandingNav", () => {
+  it("renders the logo, section anchors, and sign-in actions", () => {
+    render(<LandingNav />);
+
+    expect(
+      screen.getByRole("link", { name: /budgetiq/i })
+    ).toBeInTheDocument();
+
+    for (const anchor of ["Features", "How it works", "FAQ"]) {
+      expect(screen.getByRole("link", { name: anchor })).toBeInTheDocument();
+    }
+
+    const signIn = screen.getByRole("link", { name: /sign in/i });
+    expect(signIn).toBeInTheDocument();
+    expect(signIn).toHaveAttribute("href", "/login");
+
+    const getStarted = screen.getByRole("link", { name: /get started/i });
+    expect(getStarted).toBeInTheDocument();
+    expect(getStarted).toHaveAttribute("href", "/login");
+  });
+});

--- a/components/landing/LandingNav.tsx
+++ b/components/landing/LandingNav.tsx
@@ -1,0 +1,51 @@
+import Image from "next/image";
+import Link from "next/link";
+import ThemeToggle from "@/components/ThemeToggle";
+
+const anchors = [
+  { href: "#features", label: "Features" },
+  { href: "#how-it-works", label: "How it works" },
+  { href: "#faq", label: "FAQ" },
+];
+
+export default function LandingNav() {
+  return (
+    <header className="navbar sticky top-0 z-30 border-b border-base-300/50 bg-base-100/80 backdrop-blur">
+      <div className="navbar-start">
+        <Link href="/" className="flex items-center gap-2 px-4 text-xl font-bold">
+          <Image
+            src="/logo-icon-light.png"
+            alt="BudgetIQ logo"
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-lg"
+          />
+          BudgetIQ
+        </Link>
+      </div>
+      <div className="navbar-center hidden md:flex">
+        <ul className="menu menu-horizontal gap-1 px-1">
+          {anchors.map(({ href, label }) => (
+            <li key={href}>
+              <a
+                href={href}
+                className="text-sm text-base-content/70 transition-colors hover:text-base-content"
+              >
+                {label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="navbar-end gap-1 pr-3">
+        <ThemeToggle />
+        <Link href="/login" className="btn btn-ghost btn-sm hidden sm:inline-flex">
+          Sign in
+        </Link>
+        <Link href="/login" className="btn btn-primary btn-sm">
+          Get started
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,6 +8,6 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    setupFiles: ["./vitest.setup.ts"],
+    setupFiles: ["./vitest.setup.tsx"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,0 @@
-import "@testing-library/jest-dom/vitest";

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    className,
+    width,
+    height,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+    width?: number;
+    height?: number;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element -- plain img stands in for next/image in jsdom
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      width={width}
+      height={height}
+    />
+  ),
+}));


### PR DESCRIPTION
Closes #38

Implements the landing nav and hero from the #34 landing page redesign.

## What's included
- `LandingNav`: sticky landing nav — logo, anchors for Features / How it works / FAQ, Sign in, Get started, and the theme toggle
- `LandingHero`: headline "Your money, finally under control.", approved subheadline, [Get started free] → /login, [View on GitHub], trust strip "Free forever · Open source · No ads · Your data, yours"
- `HeroMockup`: hand-built stylized dashboard mockup — Net Balance / Monthly Spend / Total Assets cards, donut chart (theme tokens), AI chat bubble "I spent $15 on coffee" → "Logged ✓"; stacks cleanly on mobile
- Smoke render tests for hero (headline + both CTAs + trust strip) and landing nav; global `next/image` and `matchMedia` mocks moved to `vitest.setup.tsx`

The global authenticated Navbar remains absent from the landing page (renders only in (auth)/(dashboard) layouts).

Verified: `pnpm lint`, `npx tsc --noEmit`, `pnpm test` (4 passed), `pnpm build`, and dev-server SSR of /.