### PR TITLE
T5–T7 — Features/How-it-works, Testimonials/FAQ, CTA band/footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,12 @@ import { getProfile } from "@/lib/profiles";
 import { landingView } from "@/lib/landing-view";
 import LandingNav from "@/components/landing/LandingNav";
 import LandingHero from "@/components/landing/LandingHero";
+import FeaturesSection from "@/components/landing/FeaturesSection";
+import HowItWorksSection from "@/components/landing/HowItWorksSection";
+import TestimonialsSection from "@/components/landing/TestimonialsSection";
+import FaqSection from "@/components/landing/FaqSection";
+import CtaBand from "@/components/landing/CtaBand";
+import LandingFooter from "@/components/landing/LandingFooter";
 
 export default async function Home() {
   const profile = await getProfile();
@@ -16,7 +22,13 @@ export default async function Home() {
       <LandingNav />
       <main>
         <LandingHero />
+        <FeaturesSection />
+        <HowItWorksSection />
+        <TestimonialsSection />
+        <FaqSection />
+        <CtaBand />
       </main>
+      <LandingFooter />
     </div>
   );
 }

--- a/components/landing/CtaBand.test.tsx
+++ b/components/landing/CtaBand.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CtaBand from "@/components/landing/CtaBand";
+
+describe("CtaBand", () => {
+  it("renders the headline, primary CTA, and trust line", () => {
+    render(<CtaBand />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /start tracking your money in minutes/i,
+      })
+    ).toBeInTheDocument();
+
+    const getStarted = screen.getByRole("link", {
+      name: /get started/i,
+    });
+    expect(getStarted).toBeInTheDocument();
+    expect(getStarted).toHaveAttribute("href", "/login");
+
+    expect(
+      screen.getByText(/free forever · no credit card · open source/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+export default function CtaBand() {
+  return (
+    <section className="bg-base-200 py-20">
+      <div className="mx-auto max-w-4xl px-6">
+        <div className="rounded-3xl bg-gradient-to-br from-primary to-primary/70 px-6 py-16 text-center shadow-xl">
+          <h2 className="text-3xl font-bold tracking-tight text-primary-content sm:text-4xl">
+            Start tracking your money in minutes.
+          </h2>
+          <p className="mt-4 text-primary-content/80">
+            Sign in with Google and let the AI assistant take care of the data
+            entry.
+          </p>
+          <Link
+            href="/login"
+            className="btn btn-lg mt-8 border-0 bg-base-100 text-base-content hover:bg-base-200"
+          >
+            Get started
+          </Link>
+          <p className="mt-6 text-sm font-medium text-primary-content/80">
+            Free forever · No credit card · Open source
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/FaqSection.test.tsx
+++ b/components/landing/FaqSection.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FaqSection from "@/components/landing/FaqSection";
+
+describe("FaqSection", () => {
+  it("renders the section heading", () => {
+    render(<FaqSection />);
+
+    expect(
+      screen.getByRole("heading", { name: /questions, answered/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders all six questions", () => {
+    render(<FaqSection />);
+
+    const questions = [
+      /is budgetiq really free/i,
+      /is my financial data private/i,
+      /what does the ai assistant do with my data/i,
+      /is there a budget feature/i,
+      /which devices does budgetiq support/i,
+      /different from other finance apps/i,
+    ];
+
+    for (const question of questions) {
+      expect(screen.getByText(question)).toBeInTheDocument();
+    }
+  });
+
+  it("answers honestly that there is no budget feature yet", () => {
+    render(<FaqSection />);
+
+    expect(
+      screen.getByText(
+        /not yet — budgetiq tracks income, expenses, and assets; budgets are on the roadmap/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -1,0 +1,70 @@
+import SectionHeading from "@/components/landing/SectionHeading";
+
+interface FaqData {
+  question: string;
+  answer: string;
+}
+
+const faqs: FaqData[] = [
+  {
+    question: "Is BudgetIQ really free?",
+    answer:
+      "Yes — free forever, with no ads. The whole app is open source under MIT, so you can even self-host it if you like.",
+  },
+  {
+    question: "Is my financial data private?",
+    answer:
+      "Yes. Every record is protected by row-level security, so you only ever see your own data — and nothing is ever shared or sold.",
+  },
+  {
+    question: "What does the AI assistant do with my data?",
+    answer:
+      "It acts only on what you tell it — nothing more. It logs the transactions you describe and never trains on your data.",
+  },
+  {
+    question: "Is there a budget feature?",
+    answer:
+      "Not yet — BudgetIQ tracks income, expenses, and assets; budgets are on the roadmap.",
+  },
+  {
+    question: "Which devices does BudgetIQ support?",
+    answer:
+      "BudgetIQ is a responsive web app that works on desktop, tablet, and phone — no install needed.",
+  },
+  {
+    question: "How is BudgetIQ different from other finance apps?",
+    answer:
+      "AI-assisted logging from plain language, real-time net balance and asset tracking, daily financial quotes, and a fully open-source codebase — all free with no ads.",
+  },
+];
+
+function FaqItem({ question, answer, index }: FaqData & { index: number }) {
+  return (
+    <div className="collapse collapse-arrow rounded-2xl border border-base-300/60 bg-base-100">
+      <input type="radio" name="faq" defaultChecked={index === 0} />
+      <div className="collapse-title text-base font-semibold">{question}</div>
+      <div className="collapse-content text-sm leading-relaxed text-base-content/70">
+        {answer}
+      </div>
+    </div>
+  );
+}
+
+export default function FaqSection() {
+  return (
+    <section id="faq" className="scroll-mt-20 bg-base-200 py-20">
+      <div className="mx-auto max-w-3xl px-6">
+        <SectionHeading
+          eyebrow="FAQ"
+          title="Questions, answered"
+          description="Everything you might wonder before signing up — answered honestly."
+        />
+        <div className="mt-12 flex flex-col gap-3">
+          {faqs.map((faq, index) => (
+            <FaqItem key={faq.question} {...faq} index={index} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/FeaturesSection.test.tsx
+++ b/components/landing/FeaturesSection.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FeaturesSection from "@/components/landing/FeaturesSection";
+
+describe("FeaturesSection", () => {
+  it("renders the section heading", () => {
+    render(<FeaturesSection />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /everything you need to take control of your money/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders all six feature cards", () => {
+    render(<FeaturesSection />);
+
+    const titles = [
+      "Track it all in one place",
+      "Log transactions by typing",
+      "Know your numbers in real time",
+      "See where your money goes",
+      "A fresh quote every day",
+      "One-click sign-in, open source",
+    ];
+
+    for (const title of titles) {
+      expect(
+        screen.getByRole("heading", { name: new RegExp(title, "i") })
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("shows the AI natural-language logging example", () => {
+    render(<FeaturesSection />);
+
+    expect(
+      screen.getByText(/i spent \$15 on coffee/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -1,0 +1,88 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  ChartPie,
+  Gauge,
+  LogIn,
+  MessageSquare,
+  Quote,
+  Receipt,
+} from "lucide-react";
+import SectionHeading from "@/components/landing/SectionHeading";
+
+interface FeatureCardData {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+const featureCards: FeatureCardData[] = [
+  {
+    icon: Receipt,
+    title: "Track it all in one place",
+    description:
+      "Income, expenses, and assets live together in a single view — salary, bills, subscriptions, cash, and investments.",
+  },
+  {
+    icon: MessageSquare,
+    title: "Log transactions by typing",
+    description:
+      'Just say "I spent $15 on coffee" and the AI assistant records it for you — no forms, no spreadsheets.',
+  },
+  {
+    icon: Gauge,
+    title: "Know your numbers in real time",
+    description:
+      "Net balance, monthly spend, and total assets update the moment you add a transaction.",
+  },
+  {
+    icon: ChartPie,
+    title: "See where your money goes",
+    description:
+      "Interactive category breakdowns and charts turn your habits into something you can act on.",
+  },
+  {
+    icon: Quote,
+    title: "A fresh quote every day",
+    description:
+      "Daily financial quotes keep you grounded and motivated, right inside the app.",
+  },
+  {
+    icon: LogIn,
+    title: "One-click sign-in, open source",
+    description:
+      "Sign in with Google in seconds — and since BudgetIQ is open source under MIT, you can inspect every line.",
+  },
+];
+
+function FeatureCard({ icon: Icon, title, description }: FeatureCardData) {
+  return (
+    <div className="rounded-2xl border border-base-300/60 bg-base-100 p-6 shadow-sm">
+      <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <Icon className="h-6 w-6" aria-hidden="true" />
+      </div>
+      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-base-content/70">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default function FeaturesSection() {
+  return (
+    <section id="features" className="scroll-mt-20 bg-base-100 py-20">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionHeading
+          eyebrow="Features"
+          title="Everything you need to take control of your money"
+          description="A complete money tracker with an AI assistant that does the data entry for you — free and open source."
+        />
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {featureCards.map((card) => (
+            <FeatureCard key={card.title} {...card} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/HowItWorksSection.test.tsx
+++ b/components/landing/HowItWorksSection.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HowItWorksSection from "@/components/landing/HowItWorksSection";
+
+describe("HowItWorksSection", () => {
+  it("renders the section heading", () => {
+    render(<HowItWorksSection />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /tracking your money in three steps/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the three steps", () => {
+    render(<HowItWorksSection />);
+
+    const steps = [
+      "Create your account",
+      "Add transactions your way",
+      "See the bigger picture",
+    ];
+
+    for (const step of steps) {
+      expect(
+        screen.getByRole("heading", { name: new RegExp(step, "i") })
+      ).toBeInTheDocument();
+    }
+  });
+});

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,59 @@
+import SectionHeading from "@/components/landing/SectionHeading";
+
+interface StepData {
+  number: string;
+  title: string;
+  description: string;
+}
+
+const steps: StepData[] = [
+  {
+    number: "01",
+    title: "Create your account",
+    description:
+      "Sign in with Google in seconds. No credit card, no setup, no download.",
+  },
+  {
+    number: "02",
+    title: "Add transactions your way",
+    description:
+      'Type "I spent $15 on coffee" and the AI assistant logs it — or add income, expenses, and assets manually.',
+  },
+  {
+    number: "03",
+    title: "See the bigger picture",
+    description:
+      "Watch your net balance, monthly spend, and total assets add up, with category charts along the way.",
+  },
+];
+
+function StepCard({ number, title, description }: StepData) {
+  return (
+    <li className="rounded-2xl border border-base-300/60 bg-base-100 p-6">
+      <span className="text-4xl font-bold text-primary/30">{number}</span>
+      <h3 className="mt-3 text-lg font-semibold">{title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-base-content/70">
+        {description}
+      </p>
+    </li>
+  );
+}
+
+export default function HowItWorksSection() {
+  return (
+    <section id="how-it-works" className="scroll-mt-20 bg-base-200 py-20">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionHeading
+          eyebrow="How it works"
+          title="Tracking your money in three steps"
+          description="From sign-up to your first logged transaction in under a minute."
+        />
+        <ol className="mt-12 grid gap-6 md:grid-cols-3">
+          {steps.map((step) => (
+            <StepCard key={step.number} {...step} />
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/LandingFooter.test.tsx
+++ b/components/landing/LandingFooter.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import LandingFooter from "@/components/landing/LandingFooter";
+
+describe("LandingFooter", () => {
+  it("renders the license line, product anchors, and GitHub link", () => {
+    render(<LandingFooter />);
+
+    expect(
+      screen.getByText(/budgetiq · open source under mit/i)
+    ).toBeInTheDocument();
+
+    for (const anchor of [
+      "Features",
+      "How it works",
+      "Testimonials",
+      "FAQ",
+    ]) {
+      expect(
+        screen.getByRole("link", { name: anchor })
+      ).toBeInTheDocument();
+    }
+
+    const github = screen.getByRole("link", { name: /github/i });
+    expect(github).toHaveAttribute(
+      "href",
+      "https://github.com/AmineMabrouk17/BudgetIQ"
+    );
+  });
+
+  it("does not link to privacy or terms pages", () => {
+    render(<LandingFooter />);
+
+    expect(
+      screen.queryByRole("link", { name: /privacy/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /terms/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/landing/LandingFooter.tsx
+++ b/components/landing/LandingFooter.tsx
@@ -1,0 +1,40 @@
+const productLinks = [
+  { href: "#features", label: "Features" },
+  { href: "#how-it-works", label: "How it works" },
+  { href: "#testimonials", label: "Testimonials" },
+  { href: "#faq", label: "FAQ" },
+];
+
+export default function LandingFooter() {
+  return (
+    <footer className="border-t border-base-300/50 bg-base-100">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-10 sm:flex-row">
+        <p className="text-sm font-medium text-base-content/60">
+          BudgetIQ · Open source under MIT
+        </p>
+        <nav aria-label="Footer">
+          <ul className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+            {productLinks.map(({ href, label }) => (
+              <li key={href}>
+                <a
+                  href={href}
+                  className="text-sm text-base-content/70 transition-colors hover:text-base-content"
+                >
+                  {label}
+                </a>
+              </li>
+            ))}
+            <li>
+              <a
+                href="https://github.com/AmineMabrouk17/BudgetIQ"
+                className="text-sm text-base-content/70 transition-colors hover:text-base-content"
+              >
+                GitHub
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/components/landing/SectionHeading.tsx
+++ b/components/landing/SectionHeading.tsx
@@ -1,0 +1,27 @@
+interface SectionHeadingProps {
+  eyebrow: string;
+  title: string;
+  description?: string;
+}
+
+export default function SectionHeading({
+  eyebrow,
+  title,
+  description,
+}: SectionHeadingProps) {
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+        {eyebrow}
+      </p>
+      <h2 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+        {title}
+      </h2>
+      {description ? (
+        <p className="mt-4 leading-relaxed text-base-content/70">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/landing/TestimonialsSection.test.tsx
+++ b/components/landing/TestimonialsSection.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TestimonialsSection from "@/components/landing/TestimonialsSection";
+
+describe("TestimonialsSection", () => {
+  it("renders three placeholder testimonials", () => {
+    render(<TestimonialsSection />);
+
+    const quotes = [
+      /the AI assistant is the reason i stayed/i,
+      /net balance and total assets without juggling/i,
+      /my data stays mine/i,
+    ];
+
+    for (const quote of quotes) {
+      expect(screen.getByText(quote)).toBeInTheDocument();
+    }
+
+    expect(
+      screen.getAllByRole("blockquote", { hidden: false })
+    ).toHaveLength(3);
+  });
+});

--- a/components/landing/TestimonialsSection.tsx
+++ b/components/landing/TestimonialsSection.tsx
@@ -1,0 +1,65 @@
+import { Quote } from "lucide-react";
+import SectionHeading from "@/components/landing/SectionHeading";
+
+interface TestimonialData {
+  quote: string;
+  name: string;
+  role: string;
+}
+
+// Placeholder testimonials — swap these with real quotes from the maintainer
+// before launch. They are fictional and only stand in for social proof.
+const testimonials: TestimonialData[] = [
+  {
+    quote:
+      "The AI assistant is the reason I stayed. I type what I spent and it just shows up — logged, categorized, done.",
+    name: "Sarah M.",
+    role: "Early adopter",
+  },
+  {
+    quote:
+      "I finally know my net balance and total assets without juggling three different apps.",
+    name: "James T.",
+    role: "Freelancer",
+  },
+  {
+    quote:
+      "Free, open source, and my data stays mine. There aren't many finance apps you can say that about.",
+    name: "Priya K.",
+    role: "Developer",
+  },
+];
+
+function TestimonialCard({ quote, name, role }: TestimonialData) {
+  return (
+    <figure className="flex h-full flex-col rounded-2xl border border-base-300/60 bg-base-100 p-6">
+      <Quote className="h-6 w-6 text-primary" aria-hidden="true" />
+      <blockquote className="mt-4 flex-1 leading-relaxed text-base-content/80">
+        {quote}
+      </blockquote>
+      <figcaption className="mt-6">
+        <p className="font-semibold">{name}</p>
+        <p className="text-sm text-base-content/60">{role}</p>
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function TestimonialsSection() {
+  return (
+    <section id="testimonials" className="scroll-mt-20 bg-base-100 py-20">
+      <div className="mx-auto max-w-6xl px-6">
+        <SectionHeading
+          eyebrow="Testimonials"
+          title="Loved by people who track their money"
+          description="What early users say about BudgetIQ — real quotes coming soon."
+        />
+        <div className="mt-12 grid gap-6 md:grid-cols-3">
+          {testimonials.map((testimonial) => (
+            <TestimonialCard key={testimonial.name} {...testimonial} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -1,5 +1,10 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
Closes #39, closes #40, closes #41

Landing page sections from the #34 redesign, completing the full landing page.

## T5 (#39) — Features grid + How-it-works
- `FeaturesSection` (id="features"): six cards with approved copy — track income/expenses/assets, AI logging from natural language, real-time net balance/monthly spend/total assets, category charts, daily quotes, one-click sign-in + open source
- `HowItWorksSection` (id="how-it-works"): three steps — Create your account / Add transactions your way / See the bigger picture

## T6 (#40) — Testimonials + FAQ
- `TestimonialsSection` (id="testimonials"): three placeholder quotes, clearly marked in code for the maintainer to swap later
- `FaqSection` (id="faq"): six Q/A pairs, including the honest "no budget feature yet" answer

## T7 (#41) — CTA band + footer
- `CtaBand`: "Start tracking your money in minutes." with Get started → /login and "Free forever · No credit card · Open source", on a brand-green gradient card
- `LandingFooter`: product anchors, GitHub link, "BudgetIQ · Open source under MIT", no legal links

## Shared
- `SectionHeading` (eyebrow + title + description) shared by the four sections
- Sections wired into `app/page.tsx` under `<main>`; footer outside it
- 12 new co-located tests; added explicit `afterEach(cleanup)` to `vitest.setup.tsx` (RTL auto-cleanup doesn't register without `globals: true`)
- All daisyUI theme tokens (light/dark), responsive breakpoints, no new dependencies

Out of scope (lands in T8, #42): scroll-reveal motion and SEO metadata/OG image.

Verified: `pnpm lint`, `npx tsc --noEmit`, `pnpm test` (16 passed), `pnpm build`, and dev-server SSR of /.