### PR TITLE
T8 — Scroll-reveal motion + SEO metadata/OG image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { cookies } from "next/headers";
 import "./globals.css";
+import { metadata as siteMetadata } from "./metadata";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -13,10 +14,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "BudgetIQ",
-  description: "AI-powered personal finance and budget planner",
-};
+export const metadata: Metadata = siteMetadata;
 
 export default async function RootLayout({
   children,

--- a/app/metadata.test.tsx
+++ b/app/metadata.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "@/app/metadata";
+
+describe("landing page metadata", () => {
+  it("uses the updated title and description", () => {
+    expect(metadata.title).toMatch(/your money, finally under control/i);
+    expect(metadata.description).toMatch(/income, expenses, and assets/i);
+    expect(metadata.description).not.toMatch(/budget planner|coming soon/i);
+  });
+
+  it("sets an Open Graph image reusing the vertical logo asset", () => {
+    const image = Array.isArray(metadata.openGraph?.images)
+      ? metadata.openGraph?.images[0]
+      : undefined;
+
+    expect(image).toBeDefined();
+    if (typeof image === "object" && image && "url" in image) {
+      expect(image.url).toContain("logo-vertical");
+    }
+  });
+});

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  ),
+  title: "BudgetIQ — Your money, finally under control.",
+  description:
+    "BudgetIQ is a free, open-source AI-powered personal finance app. Track income, expenses, and assets — and let the AI assistant log them straight from your words.",
+  openGraph: {
+    title: "BudgetIQ — Your money, finally under control.",
+    description:
+      "Track income, expenses, and assets with an AI assistant that logs transactions from natural language. Free, open source, no ads.",
+    images: [{ url: "/logo-vertical-light.png", alt: "BudgetIQ" }],
+  },
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaBand from "@/components/landing/CtaBand";
 import LandingFooter from "@/components/landing/LandingFooter";
+import Reveal from "@/components/landing/Reveal";
 
 export default async function Home() {
   const profile = await getProfile();
@@ -21,12 +22,24 @@ export default async function Home() {
     <div className="min-h-screen bg-base-200">
       <LandingNav />
       <main>
-        <LandingHero />
-        <FeaturesSection />
-        <HowItWorksSection />
-        <TestimonialsSection />
-        <FaqSection />
-        <CtaBand />
+        <Reveal>
+          <LandingHero />
+        </Reveal>
+        <Reveal>
+          <FeaturesSection />
+        </Reveal>
+        <Reveal>
+          <HowItWorksSection />
+        </Reveal>
+        <Reveal>
+          <TestimonialsSection />
+        </Reveal>
+        <Reveal>
+          <FaqSection />
+        </Reveal>
+        <Reveal>
+          <CtaBand />
+        </Reveal>
       </main>
       <LandingFooter />
     </div>

--- a/components/landing/Reveal.test.tsx
+++ b/components/landing/Reveal.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import Reveal from "@/components/landing/Reveal";
+import { createMatchMedia } from "@/vitest.setup";
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  elements: Set<Element> = new Set();
+
+  constructor(private callback: IntersectionObserverCallback) {
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.elements.add(element);
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+
+  takeRecords() {
+    return [];
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback(
+      Array.from(this.elements).map(
+        (element) =>
+          ({ isIntersecting, target: element }) as IntersectionObserverEntry
+      ),
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    MockIntersectionObserver as unknown as typeof IntersectionObserver
+  );
+});
+
+afterEach(() => {
+  MockIntersectionObserver.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("Reveal", () => {
+  it("renders children hidden, then fades in when scrolled into view", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      createMatchMedia({ "(prefers-reduced-motion: reduce)": false })
+    );
+
+    render(<Reveal>Revealed content</Reveal>);
+
+    const content = screen.getByText("Revealed content");
+    expect(content).toHaveClass("opacity-0");
+
+    const observer = MockIntersectionObserver.instances[0];
+    expect(observer.elements.size).toBe(1);
+
+    act(() => observer.trigger(true));
+
+    expect(content).toHaveClass("opacity-100");
+  });
+
+  it("renders fully visible and skips the observer when prefers-reduced-motion is set", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      createMatchMedia({ "(prefers-reduced-motion: reduce)": true })
+    );
+
+    render(<Reveal>Static content</Reveal>);
+
+    expect(screen.getByText("Static content")).toHaveClass("opacity-100");
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+  });
+});

--- a/components/landing/Reveal.tsx
+++ b/components/landing/Reveal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(callback: () => void) {
+  const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+interface RevealProps {
+  children: ReactNode;
+}
+
+export default function Reveal({ children }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const reduced = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    if (reduced || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.15 }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => observer.disconnect();
+  }, [reduced]);
+
+  const isVisible = reduced || visible;
+
+  return (
+    <div
+      ref={ref}
+      className={`${
+        isVisible ? "opacity-100" : "opacity-0"
+      } ${reduced ? "" : "transition-opacity duration-700 ease-out"}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -6,10 +6,9 @@ afterEach(() => {
   cleanup();
 });
 
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
+export function createMatchMedia(queries: Record<string, boolean> = {}) {
+  return (query: string) => ({
+    matches: Boolean(queries[query]),
     media: query,
     onchange: null,
     addListener: () => {},
@@ -17,7 +16,12 @@ Object.defineProperty(window, "matchMedia", {
     addEventListener: () => {},
     removeEventListener: () => {},
     dispatchEvent: () => false,
-  }),
+  });
+}
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: createMatchMedia(),
 });
 
 vi.mock("next/image", () => ({


### PR DESCRIPTION
Closes #42

Finishing touches on the landing page from the #34 redesign.

## Scroll-reveal motion
- `components/landing/Reveal.tsx`: `"use client"` wrapper that fades sections in (opacity 0→100, 700ms ease-out) when an IntersectionObserver reports them 15% in view, then disconnects
- Respects `prefers-reduced-motion`: via `useSyncExternalStore` (same pattern as `ThemeToggle`), reduced-motion users get content immediately with no transition and no observer created; `getServerSnapshot` keeps SSR/hydration consistent (both render opacity-0)
- Applied to all six sections (Hero, Features, How-it-works, Testimonials, FAQ, CTA band) at the composition site in `app/page.tsx`; sticky nav and footer left unwrapped
- Native browser APIs only — no new runtime dependencies

## SEO metadata
- `app/metadata.ts` (pure module, re-exported by `app/layout.tsx` so it's unit-testable without dragging `next/font` into jsdom):
  - Title: "BudgetIQ — Your money, finally under control."
  - Description: honest, per the #34 glossary — drops the old "budget planner" line
  - OpenGraph title/description + image reusing `/logo-vertical-light.png`, resolved absolute via `metadataBase` (`NEXT_PUBLIC_SITE_URL`)

## Tests
- `Reveal.test.tsx`: fades in on intersect; renders visible and skips the observer under reduced motion
- `app/metadata.test.tsx`: title/description updated and free of banned terms; OG image set
- `createMatchMedia` helper exported from `vitest.setup.tsx` and shared by the Reveal test

Verified: `pnpm lint`, `npx tsc --noEmit`, `pnpm test` (20 passed), `pnpm build`, dev-server SSR (head tags + 6 opacity-0 reveals).