### PR TITLE
feat: apply copilot.money visual design system to landing page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,33 @@
 @import "tailwindcss";
 
 @theme inline {
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-space-grotesk);
+}
+
+/* BudgetIQ design system — copilot.money-inspired (issue #58) */
+@theme {
+  /* Base surfaces */
+  --color-night: #010d1f;
+  --color-night-alt: #001122;
+  --color-night-raised: #11263b;
+
+  /* Primary accent / CTA */
+  --color-accent: #0099ff;
+  --color-accent-bright: #3388ff;
+  --color-accent-deep: #1a66ff;
+
+  /* Secondary/muted text */
+  --color-muted: #5979a6;
+
+  /* Playful accent pops */
+  --color-pop-green: #00cc4b;
+  --color-pop-orange: #f68002;
+  --color-pop-red: #ff4433;
+  --color-pop-pink: #ea687c;
+  --color-pop-yellow: #ffcc02;
+  --color-pop-purple: #8b5cf6;
 }
 
 @plugin "daisyui" {
@@ -11,22 +36,37 @@
 
 :root,
 [data-theme="light"] {
-  --color-primary: #14b37b;
+  --color-primary: #0099ff;
   --color-primary-content: #ffffff;
 }
 
 [data-theme="dark"] {
-  --color-base-100: #0f1932;
-  --color-base-200: #0b1326;
-  --color-base-300: #080f1f;
+  --color-base-100: #11263b;
+  --color-base-200: #001122;
+  --color-base-300: #010d1f;
+  --color-primary: #0099ff;
+  --color-primary-content: #ffffff;
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
-    --color-primary: #14b37b;
+    --color-base-100: #11263b;
+    --color-base-200: #001122;
+    --color-base-300: #010d1f;
+    --color-primary: #0099ff;
     --color-primary-content: #ffffff;
-    --color-base-100: #0f1932;
-    --color-base-200: #0b1326;
-    --color-base-300: #080f1f;
   }
+}
+
+/* Added by the AntiInspect component to deter casual copying/inspection. */
+.anti-inspect {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.anti-inspect input,
+.anti-inspect textarea,
+.anti-inspect [contenteditable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono, Inter, Space_Grotesk } from "next/font/google";
 import { cookies } from "next/headers";
 import "./globals.css";
 import { metadata as siteMetadata } from "./metadata";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+  display: "swap",
+});
+
+const spaceGrotesk = Space_Grotesk({
+  variable: "--font-space-grotesk",
+  subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
@@ -31,7 +38,7 @@ export default async function RootLayout({
       lang="en"
       data-theme={dataTheme}
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable}`}
+      className={`${inter.variable} ${spaceGrotesk.variable} ${geistMono.variable}`}
     >
       <body>{children}</body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getProfile } from "@/lib/profiles";
 import { landingView } from "@/lib/landing-view";
+import AnnouncementBar from "@/components/landing/AnnouncementBar";
 import LandingNav from "@/components/landing/LandingNav";
 import LandingHero from "@/components/landing/LandingHero";
 import FeaturesSection from "@/components/landing/FeaturesSection";
@@ -19,7 +20,8 @@ export default async function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-base-200">
+    <div className="min-h-screen bg-night text-white/90 antialiased">
+      <AnnouncementBar />
       <LandingNav />
       <main>
         <Reveal>

--- a/components/landing/AnnouncementBar.test.tsx
+++ b/components/landing/AnnouncementBar.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AnnouncementBar from "@/components/landing/AnnouncementBar";
+
+describe("AnnouncementBar", () => {
+  it("renders the announcement strip copy", () => {
+    render(<AnnouncementBar />);
+
+    expect(
+      screen.getByText(/free forever · open source · no credit card required/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/landing/AnnouncementBar.tsx
+++ b/components/landing/AnnouncementBar.tsx
@@ -1,0 +1,9 @@
+export default function AnnouncementBar() {
+  return (
+    <div className="bg-accent">
+      <p className="py-2 text-center text-sm font-medium text-white">
+        Free forever · Open source · No credit card required
+      </p>
+    </div>
+  );
+}

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -2,23 +2,23 @@ import Link from "next/link";
 
 export default function CtaBand() {
   return (
-    <section className="bg-base-200 py-20">
+    <section className="bg-night py-20">
       <div className="mx-auto max-w-4xl px-6">
-        <div className="rounded-3xl bg-gradient-to-br from-primary to-primary/70 px-6 py-16 text-center shadow-xl">
-          <h2 className="text-3xl font-bold tracking-tight text-primary-content sm:text-4xl">
+        <div className="rounded-3xl bg-gradient-to-br from-accent via-accent-bright to-accent-deep px-6 py-16 text-center shadow-2xl">
+          <h2 className="text-3xl font-display font-semibold tracking-[-0.02em] text-white sm:text-4xl">
             Start tracking your money in minutes.
           </h2>
-          <p className="mt-4 text-primary-content/80">
+          <p className="mt-4 leading-[1.6] text-white/85">
             Sign in with Google and let the AI assistant take care of the data
             entry.
           </p>
           <Link
             href="/login"
-            className="btn btn-lg mt-8 border-0 bg-base-100 text-base-content hover:bg-base-200"
+            className="mt-8 inline-flex items-center rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
           >
             Get started
           </Link>
-          <p className="mt-6 text-sm font-medium text-primary-content/80">
+          <p className="mt-6 text-sm font-medium text-white/85">
             Free forever · No credit card · Open source
           </p>
         </div>

--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
 
 interface FaqData {
@@ -38,21 +39,24 @@ const faqs: FaqData[] = [
   },
 ];
 
-function FaqItem({ question, answer, index }: FaqData & { index: number }) {
+function FaqItem({ question, answer }: FaqData) {
   return (
-    <div className="collapse collapse-arrow rounded-2xl border border-base-300/60 bg-base-100">
-      <input type="radio" name="faq" defaultChecked={index === 0} />
-      <div className="collapse-title text-base font-semibold">{question}</div>
-      <div className="collapse-content text-sm leading-relaxed text-base-content/70">
-        {answer}
-      </div>
-    </div>
+    <details className="group rounded-2xl border border-white/[0.08] bg-night-raised">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-5 text-base font-semibold text-white/90 [&::-webkit-details-marker]:hidden">
+        {question}
+        <ChevronDown
+          className="h-5 w-5 shrink-0 text-muted transition-transform duration-200 group-open:rotate-180"
+          aria-hidden="true"
+        />
+      </summary>
+      <div className="px-5 pb-5 text-sm leading-[1.6] text-muted">{answer}</div>
+    </details>
   );
 }
 
 export default function FaqSection() {
   return (
-    <section id="faq" className="scroll-mt-20 bg-base-200 py-20">
+    <section id="faq" className="scroll-mt-20 bg-night-alt py-20">
       <div className="mx-auto max-w-3xl px-6">
         <SectionHeading
           eyebrow="FAQ"
@@ -60,8 +64,8 @@ export default function FaqSection() {
           description="Everything you might wonder before signing up — answered honestly."
         />
         <div className="mt-12 flex flex-col gap-3">
-          {faqs.map((faq, index) => (
-            <FaqItem key={faq.question} {...faq} index={index} />
+          {faqs.map((faq) => (
+            <FaqItem key={faq.question} {...faq} />
           ))}
         </div>
       </div>

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -9,8 +9,18 @@ import {
 } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
 
+const popClasses: Record<string, string> = {
+  green: "text-pop-green",
+  orange: "text-pop-orange",
+  purple: "text-pop-purple",
+  pink: "text-pop-pink",
+  yellow: "text-pop-yellow",
+  red: "text-pop-red",
+};
+
 interface FeatureCardData {
   icon: LucideIcon;
+  color: keyof typeof popClasses;
   title: string;
   description: string;
 }
@@ -18,59 +28,65 @@ interface FeatureCardData {
 const featureCards: FeatureCardData[] = [
   {
     icon: Receipt,
+    color: "green",
     title: "Track it all in one place",
     description:
       "Income, expenses, and assets live together in a single view — salary, bills, subscriptions, cash, and investments.",
   },
   {
     icon: MessageSquare,
+    color: "orange",
     title: "Log transactions by typing",
     description:
       'Just say "I spent $15 on coffee" and the AI assistant records it for you — no forms, no spreadsheets.',
   },
   {
     icon: Gauge,
+    color: "purple",
     title: "Know your numbers in real time",
     description:
       "Net balance, monthly spend, and total assets update the moment you add a transaction.",
   },
   {
     icon: ChartPie,
+    color: "pink",
     title: "See where your money goes",
     description:
       "Interactive category breakdowns and charts turn your habits into something you can act on.",
   },
   {
     icon: Quote,
+    color: "yellow",
     title: "A fresh quote every day",
     description:
       "Daily financial quotes keep you grounded and motivated, right inside the app.",
   },
   {
     icon: LogIn,
+    color: "red",
     title: "One-click sign-in, open source",
     description:
       "Sign in with Google in seconds — and since BudgetIQ is open source under MIT, you can inspect every line.",
   },
 ];
 
-function FeatureCard({ icon: Icon, title, description }: FeatureCardData) {
+function FeatureCard({ icon: Icon, color, title, description }: FeatureCardData) {
   return (
-    <div className="rounded-2xl border border-base-300/60 bg-base-100 p-6 shadow-sm">
-      <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
-        <Icon className="h-6 w-6" aria-hidden="true" />
+    <div className="rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg">
+      <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.04]">
+        <Icon className={`h-6 w-6 ${popClasses[color]}`} aria-hidden="true" />
       </div>
-      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
-      <p className="mt-2 text-sm leading-relaxed text-base-content/70">
-        {description}
-      </p>
+      <h3 className="mt-4 text-lg font-display font-semibold tracking-[-0.02em] text-white/90">
+        {title}
+      </h3>
+      <p className="mt-2 text-sm leading-[1.6] text-muted">{description}</p>
     </div>
   );
 }
 
 export default function FeaturesSection() {
   return (
-    <section id="features" className="scroll-mt-20 bg-base-100 py-20">
+    <section id="features" className="scroll-mt-20 bg-night py-20">
       <div className="mx-auto max-w-6xl px-6">
         <SectionHeading
           eyebrow="Features"

--- a/components/landing/HeroMockup.tsx
+++ b/components/landing/HeroMockup.tsx
@@ -15,14 +15,16 @@ const summaryCards: SummaryCardData[] = [
 
 function SummaryCard({ label, value, delta, trend }: SummaryCardData) {
   return (
-    <div className="rounded-xl border border-base-300/60 bg-base-200/60 p-3">
-      <p className="text-[10px] font-medium uppercase tracking-wide text-base-content/60">
+    <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] p-3">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-muted">
         {label}
       </p>
-      <p className="mt-1 text-sm font-bold sm:text-base">{value}</p>
+      <p className="mt-1 text-sm font-bold sm:text-base text-white/90">
+        {value}
+      </p>
       <p
         className={`mt-0.5 text-[10px] font-medium ${
-          trend === "up" ? "text-primary" : "text-base-content/50"
+          trend === "up" ? "text-pop-green" : "text-pop-red"
         }`}
       >
         {delta}
@@ -42,12 +44,12 @@ function DonutChart() {
         className="absolute inset-0 rounded-full"
         style={{
           background:
-            "conic-gradient(var(--color-primary) 0% 42%, var(--color-base-content) 42% 58%, var(--color-base-300) 58% 100%)",
+            "conic-gradient(var(--color-accent) 0% 42%, var(--color-pop-yellow) 42% 58%, rgba(255,255,255,0.12) 58% 100%)",
         }}
       />
-      <div className="absolute inset-[24%] flex flex-col items-center justify-center rounded-full bg-base-100">
-        <p className="text-sm font-bold">$1,250</p>
-        <p className="text-[10px] text-base-content/60">saved</p>
+      <div className="absolute inset-[24%] flex flex-col items-center justify-center rounded-full bg-night-raised ring-1 ring-white/[0.08]">
+        <p className="text-sm font-bold text-white/90">$1,250</p>
+        <p className="text-[10px] text-muted">saved</p>
       </div>
     </div>
   );
@@ -55,22 +57,20 @@ function DonutChart() {
 
 export default function HeroMockup() {
   return (
-    <div className="mx-auto w-full max-w-md rounded-2xl border border-base-300/60 bg-base-100 p-6 shadow-xl">
+    <div className="relative mx-auto w-full max-w-md rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-2xl">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex gap-1.5">
-          <span className="h-3 w-3 rounded-full bg-error/70" aria-hidden="true" />
+          <span className="h-3 w-3 rounded-full bg-pop-red/70" aria-hidden="true" />
           <span
-            className="h-3 w-3 rounded-full bg-warning/70"
+            className="h-3 w-3 rounded-full bg-pop-yellow/70"
             aria-hidden="true"
           />
           <span
-            className="h-3 w-3 rounded-full bg-success/70"
+            className="h-3 w-3 rounded-full bg-pop-green/70"
             aria-hidden="true"
           />
         </div>
-        <p className="text-xs font-medium text-base-content/60">
-          BudgetIQ dashboard
-        </p>
+        <p className="text-xs font-medium text-muted">BudgetIQ dashboard</p>
       </div>
 
       <div className="grid grid-cols-3 gap-3">
@@ -82,10 +82,10 @@ export default function HeroMockup() {
       <div className="mt-6 flex items-center gap-4">
         <DonutChart />
         <div className="flex flex-1 flex-col gap-2">
-          <div className="max-w-[85%] self-start rounded-2xl rounded-bl-sm bg-base-200 px-4 py-2 text-sm text-base-content">
+          <div className="max-w-[85%] self-start rounded-2xl rounded-bl-sm bg-white/10 px-4 py-2 text-sm text-white/90">
             I spent $15 on coffee
           </div>
-          <div className="max-w-[85%] self-end rounded-2xl rounded-br-sm bg-primary px-4 py-2 text-sm font-medium text-primary-content">
+          <div className="max-w-[85%] self-end rounded-2xl rounded-br-sm bg-accent px-4 py-2 text-sm font-medium text-white">
             Logged ✓
           </div>
         </div>

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -4,6 +4,7 @@ interface StepData {
   number: string;
   title: string;
   description: string;
+  colorClass: string;
 }
 
 const steps: StepData[] = [
@@ -12,36 +13,39 @@ const steps: StepData[] = [
     title: "Create your account",
     description:
       "Sign in with Google in seconds. No credit card, no setup, no download.",
+    colorClass: "text-pop-green",
   },
   {
     number: "02",
     title: "Add transactions your way",
     description:
       'Type "I spent $15 on coffee" and the AI assistant logs it — or add income, expenses, and assets manually.',
+    colorClass: "text-pop-yellow",
   },
   {
     number: "03",
     title: "See the bigger picture",
     description:
       "Watch your net balance, monthly spend, and total assets add up, with category charts along the way.",
+    colorClass: "text-pop-purple",
   },
 ];
 
-function StepCard({ number, title, description }: StepData) {
+function StepCard({ number, title, description, colorClass }: StepData) {
   return (
-    <li className="rounded-2xl border border-base-300/60 bg-base-100 p-6">
-      <span className="text-4xl font-bold text-primary/30">{number}</span>
-      <h3 className="mt-3 text-lg font-semibold">{title}</h3>
-      <p className="mt-2 text-sm leading-relaxed text-base-content/70">
-        {description}
-      </p>
+    <li className="rounded-2xl border border-white/[0.08] bg-night-raised p-6">
+      <span className={`text-4xl font-bold ${colorClass}`}>{number}</span>
+      <h3 className="mt-3 text-lg font-display font-semibold tracking-[-0.02em] text-white/90">
+        {title}
+      </h3>
+      <p className="mt-2 text-sm leading-[1.6] text-muted">{description}</p>
     </li>
   );
 }
 
 export default function HowItWorksSection() {
   return (
-    <section id="how-it-works" className="scroll-mt-20 bg-base-200 py-20">
+    <section id="how-it-works" className="scroll-mt-20 bg-night-alt py-20">
       <div className="mx-auto max-w-6xl px-6">
         <SectionHeading
           eyebrow="How it works"

--- a/components/landing/LandingFooter.tsx
+++ b/components/landing/LandingFooter.tsx
@@ -7,9 +7,9 @@ const productLinks = [
 
 export default function LandingFooter() {
   return (
-    <footer className="border-t border-base-300/50 bg-base-100">
+    <footer className="border-t border-white/[0.08] bg-night">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-10 sm:flex-row">
-        <p className="text-sm font-medium text-base-content/60">
+        <p className="text-sm font-medium text-muted">
           BudgetIQ · Open source under MIT
         </p>
         <nav aria-label="Footer">
@@ -18,7 +18,7 @@ export default function LandingFooter() {
               <li key={href}>
                 <a
                   href={href}
-                  className="text-sm text-base-content/70 transition-colors hover:text-base-content"
+                  className="text-sm text-muted transition-colors hover:text-white/90"
                 >
                   {label}
                 </a>

--- a/components/landing/LandingHero.test.tsx
+++ b/components/landing/LandingHero.test.tsx
@@ -32,4 +32,10 @@ describe("LandingHero", () => {
       screen.getByText(/free forever · open source · no ads · your data, yours/i)
     ).toBeInTheDocument();
   });
+
+  it("renders the Groceries pill tag", () => {
+    render(<LandingHero />);
+
+    expect(screen.getByText(/groceries/i)).toBeInTheDocument();
+  });
 });

--- a/components/landing/LandingHero.tsx
+++ b/components/landing/LandingHero.tsx
@@ -1,34 +1,109 @@
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import HeroMockup from "@/components/landing/HeroMockup";
+import PillTag from "@/components/landing/PillTag";
+
+function GithubIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="h-4 w-4"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.269 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.523 2 12 2Z"
+      />
+    </svg>
+  );
+}
 
 export default function LandingHero() {
   return (
-    <section className="mx-auto grid w-full max-w-6xl items-center gap-12 px-6 pb-20 pt-12 lg:grid-cols-2 lg:pb-24 lg:pt-16">
-      <div>
-        <h1 className="text-4xl font-bold leading-tight tracking-tight sm:text-5xl">
-          Your money, finally under control.
+    <section className="relative mx-auto w-full max-w-6xl overflow-visible px-6 pb-24 pt-20 text-center lg:pt-28">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute top-10 left-1/4 -z-10 h-72 w-72 rounded-full bg-accent/25 blur-[120px]"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute right-1/4 bottom-0 -z-10 h-72 w-72 rounded-full bg-pop-purple/20 blur-[120px]"
+      />
+
+      <div className="relative">
+        <PillTag
+          emoji="🥑"
+          label="Groceries"
+          colorClass="bg-pop-green"
+          rotationDeg={-8}
+          className="absolute -left-2 top-6 z-10 hidden md:inline-flex"
+        />
+        <PillTag
+          emoji="🧸"
+          label="Baby"
+          colorClass="bg-pop-pink"
+          rotationDeg={7}
+          className="absolute right-0 top-10 z-10 hidden md:inline-flex"
+        />
+        <PillTag
+          emoji="☕"
+          label="Coffee"
+          colorClass="bg-pop-orange"
+          rotationDeg={-6}
+          className="absolute left-4 top-1/2 z-10 hidden md:inline-flex"
+        />
+        <PillTag
+          emoji="🎬"
+          label="Subscriptions"
+          colorClass="bg-pop-purple"
+          rotationDeg={9}
+          className="absolute top-1/2 right-6 z-10 hidden md:inline-flex"
+        />
+        <PillTag
+          emoji="✈️"
+          label="Travel"
+          colorClass="bg-pop-yellow"
+          rotationDeg={-9}
+          className="absolute bottom-0 left-8 z-10 hidden md:inline-flex"
+        />
+        <h1 className="mx-auto max-w-5xl font-display text-[length:clamp(3rem,9vw,9rem)] leading-[0.9] font-semibold tracking-[-0.02em] text-white/90">
+          <span className="block">Your money,</span>
+          <span className="block">finally under control.</span>
         </h1>
-        <p className="mt-6 max-w-xl text-lg leading-relaxed text-base-content/70">
-          BudgetIQ is a free, open-source personal finance app. Track income,
-          expenses, and assets — and let the AI assistant log them straight
-          from your words. Sign in with Google in seconds.
-        </p>
-        <div className="mt-8 flex flex-wrap items-center gap-3">
-          <Link href="/login" className="btn btn-primary btn-lg">
-            Get started free
-          </Link>
-          <a
-            href="https://github.com/AmineMabrouk17/BudgetIQ"
-            className="btn btn-outline btn-lg"
-          >
-            View on GitHub
-          </a>
-        </div>
-        <p className="mt-10 text-sm font-medium tracking-wide text-base-content/60">
-          Free forever · Open source · No ads · Your data, yours
-        </p>
       </div>
-      <HeroMockup />
+
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-[1.6] text-muted">
+        BudgetIQ is a free, open-source personal finance app. Track income,
+        expenses, and assets — and let the AI assistant log them straight from
+        your words. Sign in with Google in seconds.
+      </p>
+
+      <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+        <Link
+          href="/login"
+          className="inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-accent-bright"
+        >
+          Get started free
+          <ArrowRight aria-hidden="true" className="h-4 w-4" />
+        </Link>
+        <a
+          href="https://github.com/AmineMabrouk17/BudgetIQ"
+          className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
+        >
+          <GithubIcon />
+          View on GitHub
+        </a>
+      </div>
+
+      <p className="mt-14 text-[13px] uppercase tracking-[0.01em] text-muted">
+        Free forever · Open source · No ads · Your data, yours
+      </p>
+
+      <div className="mx-auto mt-16 w-full max-w-xl">
+        <HeroMockup />
+      </div>
     </section>
   );
 }

--- a/components/landing/LandingNav.test.tsx
+++ b/components/landing/LandingNav.test.tsx
@@ -14,9 +14,9 @@ describe("LandingNav", () => {
       expect(screen.getByRole("link", { name: anchor })).toBeInTheDocument();
     }
 
-    const signIn = screen.getByRole("link", { name: /sign in/i });
-    expect(signIn).toBeInTheDocument();
-    expect(signIn).toHaveAttribute("href", "/login");
+    const logIn = screen.getByRole("link", { name: /log in/i });
+    expect(logIn).toBeInTheDocument();
+    expect(logIn).toHaveAttribute("href", "/login");
 
     const getStarted = screen.getByRole("link", { name: /get started/i });
     expect(getStarted).toBeInTheDocument();

--- a/components/landing/LandingNav.tsx
+++ b/components/landing/LandingNav.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import ThemeToggle from "@/components/ThemeToggle";
 
 const anchors = [
   { href: "#features", label: "Features" },
@@ -10,9 +9,9 @@ const anchors = [
 
 export default function LandingNav() {
   return (
-    <header className="navbar sticky top-0 z-30 border-b border-base-300/50 bg-base-100/80 backdrop-blur">
-      <div className="navbar-start">
-        <Link href="/" className="flex items-center gap-2 px-4 text-xl font-bold">
+    <header className="sticky top-0 z-30 bg-night/60 backdrop-blur-md">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <Link href="/" className="flex items-center gap-2">
           <Image
             src="/logo-icon-light.png"
             alt="BudgetIQ logo"
@@ -20,31 +19,35 @@ export default function LandingNav() {
             height={32}
             className="h-8 w-8 rounded-lg"
           />
-          BudgetIQ
+          <span className="font-display font-bold text-lg text-white/90">
+            BudgetIQ
+          </span>
         </Link>
-      </div>
-      <div className="navbar-center hidden md:flex">
-        <ul className="menu menu-horizontal gap-1 px-1">
+        <nav className="hidden items-center gap-8 md:flex">
           {anchors.map(({ href, label }) => (
-            <li key={href}>
-              <a
-                href={href}
-                className="text-sm text-base-content/70 transition-colors hover:text-base-content"
-              >
-                {label}
-              </a>
-            </li>
+            <a
+              key={href}
+              href={href}
+              className="text-sm font-medium text-muted transition-colors hover:text-white/90"
+            >
+              {label}
+            </a>
           ))}
-        </ul>
-      </div>
-      <div className="navbar-end gap-1 pr-3">
-        <ThemeToggle />
-        <Link href="/login" className="btn btn-ghost btn-sm hidden sm:inline-flex">
-          Sign in
-        </Link>
-        <Link href="/login" className="btn btn-primary btn-sm">
-          Get started
-        </Link>
+        </nav>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/login"
+            className="hidden text-sm font-medium text-white/90 transition-colors hover:text-white sm:inline-flex"
+          >
+            Log in
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
+          >
+            Get started
+          </Link>
+        </div>
       </div>
     </header>
   );

--- a/components/landing/PillTag.tsx
+++ b/components/landing/PillTag.tsx
@@ -1,0 +1,29 @@
+interface PillTagProps {
+  emoji: string;
+  label: string;
+  colorClass: string;
+  rotationDeg: number;
+  className?: string;
+}
+
+export default function PillTag({
+  emoji,
+  label,
+  colorClass,
+  rotationDeg,
+  className,
+}: PillTagProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold text-[#010D1F] shadow-lg ${colorClass} ${className ?? ""}`}
+      style={{
+        transform: `rotate(${rotationDeg}deg)`,
+        boxShadow:
+          "inset 0 1px 0 rgba(255,255,255,0.45), inset 0 -2px 4px rgba(0,0,0,0.15), 0 16px 32px -12px rgba(0,0,0,0.55)",
+      }}
+    >
+      <span aria-hidden="true">{emoji}</span>
+      {label}
+    </span>
+  );
+}

--- a/components/landing/SectionHeading.tsx
+++ b/components/landing/SectionHeading.tsx
@@ -11,16 +11,14 @@ export default function SectionHeading({
 }: SectionHeadingProps) {
   return (
     <div className="mx-auto max-w-2xl text-center">
-      <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+      <p className="text-[13px] uppercase tracking-[0.01em] text-muted">
         {eyebrow}
       </p>
-      <h2 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+      <h2 className="mt-3 text-3xl font-display font-semibold tracking-[-0.02em] text-white/90 sm:text-4xl md:text-5xl">
         {title}
       </h2>
       {description ? (
-        <p className="mt-4 leading-relaxed text-base-content/70">
-          {description}
-        </p>
+        <p className="mt-4 leading-[1.6] text-muted">{description}</p>
       ) : null}
     </div>
   );

--- a/components/landing/TestimonialsSection.tsx
+++ b/components/landing/TestimonialsSection.tsx
@@ -32,14 +32,14 @@ const testimonials: TestimonialData[] = [
 
 function TestimonialCard({ quote, name, role }: TestimonialData) {
   return (
-    <figure className="flex h-full flex-col rounded-2xl border border-base-300/60 bg-base-100 p-6">
-      <Quote className="h-6 w-6 text-primary" aria-hidden="true" />
-      <blockquote className="mt-4 flex-1 leading-relaxed text-base-content/80">
+    <figure className="flex h-full flex-col rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg">
+      <Quote className="h-6 w-6 text-pop-yellow" aria-hidden="true" />
+      <blockquote className="mt-4 flex-1 leading-[1.6] text-white/80">
         {quote}
       </blockquote>
       <figcaption className="mt-6">
-        <p className="font-semibold">{name}</p>
-        <p className="text-sm text-base-content/60">{role}</p>
+        <p className="font-semibold text-white/90">{name}</p>
+        <p className="text-sm text-muted">{role}</p>
       </figcaption>
     </figure>
   );
@@ -47,7 +47,7 @@ function TestimonialCard({ quote, name, role }: TestimonialData) {
 
 export default function TestimonialsSection() {
   return (
-    <section id="testimonials" className="scroll-mt-20 bg-base-100 py-20">
+    <section id="testimonials" className="scroll-mt-20 bg-night py-20">
       <div className="mx-auto max-w-6xl px-6">
         <SectionHeading
           eyebrow="Testimonials"


### PR DESCRIPTION
Closes #58

## Summary

Applies the copilot.money visual design system to the BudgetIQ landing page per the exact specifications in #58: dark premium fintech base with playful colorful accents, giant display typography, pill CTAs, and soft glows.

## Changes

### Foundation
- **`app/globals.css`** — new Tailwind v4 `@theme` tokens matching the exact spec palette:
  - Surfaces: night `#010D1F`, alt `#001122`, raised `#11263B`
  - Accent: `#0099FF` (+ gradient stops `#3388FF`, `#1A66FF`)
  - Muted text: `#5979A6`; pops: green `#00CC4B`, orange `#F68002`, red `#FF4433`, pink `#EA687C`, yellow `#FFCC02`, purple `#8B5CF6`
  - daisyUI dark theme bases remapped to the navy family; primary → electric blue in both themes (dashboard stays functional)
- **`app/layout.tsx`** — Geist Sans replaced by **Inter** (body/UI, closest free Matter alternative) and **Space Grotesk** added as the display font (closest free Jokker alternative), self-hosted via `next/font`

### Landing page (`app/page.tsx` + `components/landing/`)
- **AnnouncementBar (new):** full-width electric blue strip, centered white text
- **LandingNav:** minimal transparent-over-dark nav — logo left, 3 text links center, "Log in" + white pill "Get started" right; ThemeToggle removed from landing only (dashboard keeps its own)
- **LandingHero:** rebuilt as a centered hero — two-line headline at `clamp(3rem, 9vw, 9rem)`, weight 600, `-0.02em` tracking, `0.9` line-height; five glossy 3D pill tags (🥑 Groceries, 🧸 Baby, ☕ Coffee, 🎬 Subscriptions, ✈️ Travel) floating around/overlapping the headline at ±5–10° rotations via the new **PillTag (new)** component; blurred accent/purple glows behind key elements; primary electric-blue pill CTA with arrow icon + white pill GitHub CTA; uppercase small-label trust strip
- **HeroMockup:** restyled to dark surface card with pop-colored donut segments and chat bubbles
- **Sections:** alternating `#010D1F` / `#001122` backgrounds; cards as rounded-2xl `#11263B` surfaces with thin `rgba(255,255,255,0.08)` borders; feature icons and step numbers use playful pop colors; FAQ migrated off daisyUI collapse to native details/summary; CTA band uses the `#0099FF → #1A66FF` gradient with white pill button; footer on navy with hairline border
- All copy preserved verbatim to keep SEO/test continuity

## Verification
- vitest: **12 files / 22 tests passing** (incl. new AnnouncementBar test)
- eslint: clean
- tsc --noEmit: clean (only pre-existing stale `.next/types` currency-rates artifact from another branch)
- next build: succeeds (fonts self-hosted at build time)

## Manual review
Run `pnpm dev` and check `/` — announcement bar, nav, hero pills/glows, section rhythm, cards, FAQ accordion, CTA band.
