### PR TITLE
feat: add motion system to landing page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -70,3 +70,76 @@
   -webkit-user-select: text;
   user-select: text;
 }
+
+/* Motion system (issue #58 follow-up): load + scroll animations */
+
+@keyframes bi-rise {
+  from {
+    opacity: 0;
+    transform: translateY(1.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes bi-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes bi-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-0.5rem);
+  }
+}
+
+@keyframes bi-drift {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(2rem) scale(1.06);
+  }
+}
+
+.bi-rise {
+  animation: bi-rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.bi-pop {
+  animation: bi-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.bi-float {
+  animation: bi-float 6s ease-in-out infinite;
+}
+
+.bi-drift {
+  animation: bi-drift 14s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bi-rise,
+  .bi-pop,
+  .bi-float,
+  .bi-drift {
+    animation: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,6 @@ import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import FaqSection from "@/components/landing/FaqSection";
 import CtaBand from "@/components/landing/CtaBand";
 import LandingFooter from "@/components/landing/LandingFooter";
-import Reveal from "@/components/landing/Reveal";
 
 export default async function Home() {
   const profile = await getProfile();
@@ -24,24 +23,12 @@ export default async function Home() {
       <AnnouncementBar />
       <LandingNav />
       <main>
-        <Reveal>
-          <LandingHero />
-        </Reveal>
-        <Reveal>
-          <FeaturesSection />
-        </Reveal>
-        <Reveal>
-          <HowItWorksSection />
-        </Reveal>
-        <Reveal>
-          <TestimonialsSection />
-        </Reveal>
-        <Reveal>
-          <FaqSection />
-        </Reveal>
-        <Reveal>
-          <CtaBand />
-        </Reveal>
+        <LandingHero />
+        <FeaturesSection />
+        <HowItWorksSection />
+        <TestimonialsSection />
+        <FaqSection />
+        <CtaBand />
       </main>
       <LandingFooter />
     </div>

--- a/components/landing/AnimatedHeroTitle.test.tsx
+++ b/components/landing/AnimatedHeroTitle.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AnimatedHeroTitle from "@/components/landing/AnimatedHeroTitle";
+
+describe("AnimatedHeroTitle", () => {
+  it("renders both headline lines inside a single accessible h1", () => {
+    render(
+      <AnimatedHeroTitle lines={["Your money,", "finally under control."]} />
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /your money, finally under control/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Your")).toBeInTheDocument();
+    expect(screen.getByText("money,")).toBeInTheDocument();
+    expect(screen.getByText("finally")).toBeInTheDocument();
+    expect(screen.getByText("under")).toBeInTheDocument();
+    expect(screen.getByText("control.")).toBeInTheDocument();
+  });
+});

--- a/components/landing/AnimatedHeroTitle.tsx
+++ b/components/landing/AnimatedHeroTitle.tsx
@@ -1,0 +1,54 @@
+interface AnimatedHeroTitleProps {
+  lines: string[];
+}
+
+const BASE_DELAY_MS = 150;
+const WORD_STEP_MS = 90;
+
+interface PreparedWord {
+  word: string;
+  delayMs: number;
+}
+
+interface PreparedLine {
+  text: string;
+  words: PreparedWord[];
+}
+
+function prepareLines(lines: string[]): PreparedLine[] {
+  const prepared: PreparedLine[] = [];
+  let wordIndex = 0;
+  for (const line of lines) {
+    const words = line.split(" ").map((word): PreparedWord => {
+      const preparedWord = {
+        word,
+        delayMs: BASE_DELAY_MS + wordIndex * WORD_STEP_MS,
+      };
+      wordIndex += 1;
+      return preparedWord;
+    });
+    prepared.push({ text: line, words });
+  }
+  return prepared;
+}
+
+export default function AnimatedHeroTitle({ lines }: AnimatedHeroTitleProps) {
+  const preparedLines = prepareLines(lines);
+  return (
+    <h1 className="mx-auto max-w-5xl font-display text-[length:clamp(3rem,9vw,9rem)] leading-[0.9] font-semibold tracking-[-0.02em] text-white/90">
+      {preparedLines.map((line) => (
+        <span key={line.text} aria-hidden={false} className="block">
+          {line.words.map((preparedWord) => (
+            <span
+              key={`${line.text}-${preparedWord.delayMs}`}
+              className="bi-rise inline-block will-change-transform"
+              style={{ animationDelay: `${preparedWord.delayMs}ms` }}
+            >
+              {preparedWord.word}{" "}
+            </span>
+          ))}
+        </span>
+      ))}
+    </h1>
+  );
+}

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -1,27 +1,49 @@
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import Parallax from "@/components/landing/Parallax";
+import Reveal from "@/components/landing/Reveal";
 
 export default function CtaBand() {
   return (
     <section className="bg-night py-20">
       <div className="mx-auto max-w-4xl px-6">
-        <div className="rounded-3xl bg-gradient-to-br from-accent via-accent-bright to-accent-deep px-6 py-16 text-center shadow-2xl">
-          <h2 className="text-3xl font-display font-semibold tracking-[-0.02em] text-white sm:text-4xl">
-            Start tracking your money in minutes.
-          </h2>
-          <p className="mt-4 leading-[1.6] text-white/85">
-            Sign in with Google and let the AI assistant take care of the data
-            entry.
-          </p>
-          <Link
-            href="/login"
-            className="mt-8 inline-flex items-center rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
-          >
-            Get started
-          </Link>
-          <p className="mt-6 text-sm font-medium text-white/85">
-            Free forever · No credit card · Open source
-          </p>
-        </div>
+        <Reveal variant="scale">
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-accent via-accent-bright to-accent-deep px-6 py-16 text-center shadow-2xl">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-16 -right-16 h-56 w-56 rounded-full bg-white/20 blur-3xl bi-drift"
+            />
+            <h2 className="text-3xl font-display font-semibold tracking-[-0.02em] text-white sm:text-4xl">
+              Start tracking your money in minutes.
+            </h2>
+            <p className="mt-4 leading-[1.6] text-white/85">
+              Sign in with Google and let the AI assistant take care of the data
+              entry.
+            </p>
+            <Link
+              href="/login"
+              className="group mt-8 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-all duration-300 hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-xl active:translate-y-0 motion-reduce:hover:transform-none"
+            >
+              Get started
+              <ArrowRight
+                aria-hidden="true"
+                className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1 motion-reduce:group-hover:translate-x-0"
+              />
+            </Link>
+            <p className="mt-6 text-sm font-medium text-white/85">
+              Free forever · No credit card · Open source
+            </p>
+          </div>
+        </Reveal>
+        <Parallax
+          speed={0.1}
+          className="pointer-events-none mx-auto mt-8 h-40 w-2/3 max-w-xl"
+        >
+          <div
+            aria-hidden="true"
+            className="h-full w-full rounded-full bg-accent/30 blur-[100px]"
+          />
+        </Parallax>
       </div>
     </section>
   );

--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
+import Reveal from "@/components/landing/Reveal";
 
 interface FaqData {
   question: string;
@@ -41,7 +42,7 @@ const faqs: FaqData[] = [
 
 function FaqItem({ question, answer }: FaqData) {
   return (
-    <details className="group rounded-2xl border border-white/[0.08] bg-night-raised">
+    <details className="group rounded-2xl border border-white/[0.08] bg-night-raised transition-colors duration-300 hover:border-white/[0.18] hover:bg-white/[0.02] motion-reduce:transition-none">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-5 text-base font-semibold text-white/90 [&::-webkit-details-marker]:hidden">
         {question}
         <ChevronDown
@@ -64,8 +65,10 @@ export default function FaqSection() {
           description="Everything you might wonder before signing up — answered honestly."
         />
         <div className="mt-12 flex flex-col gap-3">
-          {faqs.map((faq) => (
-            <FaqItem key={faq.question} {...faq} />
+          {faqs.map((faq, index) => (
+            <Reveal key={faq.question} variant="up" delay={index * 70}>
+              <FaqItem {...faq} />
+            </Reveal>
           ))}
         </div>
       </div>

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -8,6 +8,7 @@ import {
   Receipt,
 } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
+import Reveal from "@/components/landing/Reveal";
 
 const popClasses: Record<string, string> = {
   green: "text-pop-green",
@@ -72,8 +73,8 @@ const featureCards: FeatureCardData[] = [
 
 function FeatureCard({ icon: Icon, color, title, description }: FeatureCardData) {
   return (
-    <div className="rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg">
-      <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.04]">
+    <div className="group h-full rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-white/[0.18] hover:shadow-[0_24px_48px_-16px_rgba(0,0,0,0.55)] motion-reduce:hover:transform-none motion-reduce:transition-none">
+      <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.04] transition-transform duration-300 group-hover:scale-110 motion-reduce:group-hover:scale-100">
         <Icon className={`h-6 w-6 ${popClasses[color]}`} aria-hidden="true" />
       </div>
       <h3 className="mt-4 text-lg font-display font-semibold tracking-[-0.02em] text-white/90">
@@ -94,8 +95,15 @@ export default function FeaturesSection() {
           description="A complete money tracker with an AI assistant that does the data entry for you — free and open source."
         />
         <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {featureCards.map((card) => (
-            <FeatureCard key={card.title} {...card} />
+          {featureCards.map((card, index) => (
+            <Reveal
+              key={card.title}
+              variant="up"
+              delay={index * 90}
+              className="h-full"
+            >
+              <FeatureCard {...card} />
+            </Reveal>
           ))}
         </div>
       </div>

--- a/components/landing/HeroMockup.tsx
+++ b/components/landing/HeroMockup.tsx
@@ -57,7 +57,7 @@ function DonutChart() {
 
 export default function HeroMockup() {
   return (
-    <div className="relative mx-auto w-full max-w-md rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-2xl">
+    <div className="relative mx-auto w-full max-w-md rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-2xl transition-transform duration-500 ease-out hover:-translate-y-1 hover:scale-[1.01] motion-reduce:hover:transform-none motion-reduce:transition-none">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex gap-1.5">
           <span className="h-3 w-3 rounded-full bg-pop-red/70" aria-hidden="true" />

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -1,4 +1,5 @@
 import SectionHeading from "@/components/landing/SectionHeading";
+import Reveal from "@/components/landing/Reveal";
 
 interface StepData {
   number: string;
@@ -33,13 +34,17 @@ const steps: StepData[] = [
 
 function StepCard({ number, title, description, colorClass }: StepData) {
   return (
-    <li className="rounded-2xl border border-white/[0.08] bg-night-raised p-6">
-      <span className={`text-4xl font-bold ${colorClass}`}>{number}</span>
+    <div className="group h-full rounded-2xl border border-white/[0.08] bg-night-raised p-6 transition-all duration-300 hover:-translate-y-1 hover:border-white/[0.18] hover:shadow-[0_24px_48px_-16px_rgba(0,0,0,0.55)] motion-reduce:hover:transform-none motion-reduce:transition-none">
+      <span
+        className={`text-4xl font-bold ${colorClass} transition-transform duration-300 group-hover:-translate-y-0.5 motion-reduce:group-hover:translate-y-0`}
+      >
+        {number}
+      </span>
       <h3 className="mt-3 text-lg font-display font-semibold tracking-[-0.02em] text-white/90">
         {title}
       </h3>
       <p className="mt-2 text-sm leading-[1.6] text-muted">{description}</p>
-    </li>
+    </div>
   );
 }
 
@@ -52,9 +57,13 @@ export default function HowItWorksSection() {
           title="Tracking your money in three steps"
           description="From sign-up to your first logged transaction in under a minute."
         />
-        <ol className="mt-12 grid gap-6 md:grid-cols-3">
-          {steps.map((step) => (
-            <StepCard key={step.number} {...step} />
+        <ol className="mt-12 grid list-none gap-6 md:grid-cols-3">
+          {steps.map((step, index) => (
+            <li key={step.number} className="h-full">
+              <Reveal variant="up" delay={index * 110} className="h-full">
+                <StepCard {...step} />
+              </Reveal>
+            </li>
           ))}
         </ol>
       </div>

--- a/components/landing/LandingFooter.tsx
+++ b/components/landing/LandingFooter.tsx
@@ -18,7 +18,7 @@ export default function LandingFooter() {
               <li key={href}>
                 <a
                   href={href}
-                  className="text-sm text-muted transition-colors hover:text-white/90"
+                  className="relative text-sm text-muted transition-colors hover:text-white/90 after:absolute after:-bottom-0.5 after:left-0 after:h-px after:w-0 after:bg-current after:transition-all after:duration-300 hover:after:w-full motion-reduce:after:hidden"
                 >
                   {label}
                 </a>
@@ -27,7 +27,7 @@ export default function LandingFooter() {
             <li>
               <a
                 href="https://github.com/AmineMabrouk17/BudgetIQ"
-                className="text-sm text-base-content/70 transition-colors hover:text-base-content"
+                className="relative text-sm text-base-content/70 transition-colors hover:text-base-content after:absolute after:-bottom-0.5 after:left-0 after:h-px after:w-0 after:bg-current after:transition-all after:duration-300 hover:after:w-full motion-reduce:after:hidden"
               >
                 GitHub
               </a>

--- a/components/landing/LandingHero.tsx
+++ b/components/landing/LandingHero.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import AnimatedHeroTitle from "@/components/landing/AnimatedHeroTitle";
 import HeroMockup from "@/components/landing/HeroMockup";
+import Parallax from "@/components/landing/Parallax";
 import PillTag from "@/components/landing/PillTag";
 
 function GithubIcon() {
@@ -23,14 +25,24 @@ function GithubIcon() {
 export default function LandingHero() {
   return (
     <section className="relative mx-auto w-full max-w-6xl overflow-visible px-6 pb-24 pt-20 text-center lg:pt-28">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute top-10 left-1/4 -z-10 h-72 w-72 rounded-full bg-accent/25 blur-[120px]"
-      />
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute right-1/4 bottom-0 -z-10 h-72 w-72 rounded-full bg-pop-purple/20 blur-[120px]"
-      />
+      <Parallax
+        speed={0.12}
+        className="pointer-events-none absolute top-10 left-1/4 -z-10"
+      >
+        <div
+          aria-hidden="true"
+          className="bi-drift h-72 w-72 rounded-full bg-accent/25 blur-[120px]"
+        />
+      </Parallax>
+      <Parallax
+        speed={-0.08}
+        className="pointer-events-none absolute right-1/4 bottom-0 -z-10"
+      >
+        <div
+          aria-hidden="true"
+          className="bi-drift h-72 w-72 rounded-full bg-pop-purple/20 blur-[120px]"
+        />
+      </Parallax>
 
       <div className="relative">
         <PillTag
@@ -38,6 +50,7 @@ export default function LandingHero() {
           label="Groceries"
           colorClass="bg-pop-green"
           rotationDeg={-8}
+          popDelay={700}
           className="absolute -left-2 top-6 z-10 hidden md:inline-flex"
         />
         <PillTag
@@ -45,6 +58,7 @@ export default function LandingHero() {
           label="Baby"
           colorClass="bg-pop-pink"
           rotationDeg={7}
+          popDelay={850}
           className="absolute right-0 top-10 z-10 hidden md:inline-flex"
         />
         <PillTag
@@ -52,6 +66,7 @@ export default function LandingHero() {
           label="Coffee"
           colorClass="bg-pop-orange"
           rotationDeg={-6}
+          popDelay={1000}
           className="absolute left-4 top-1/2 z-10 hidden md:inline-flex"
         />
         <PillTag
@@ -59,6 +74,7 @@ export default function LandingHero() {
           label="Subscriptions"
           colorClass="bg-pop-purple"
           rotationDeg={9}
+          popDelay={1150}
           className="absolute top-1/2 right-6 z-10 hidden md:inline-flex"
         />
         <PillTag
@@ -66,15 +82,16 @@ export default function LandingHero() {
           label="Travel"
           colorClass="bg-pop-yellow"
           rotationDeg={-9}
+          popDelay={1300}
           className="absolute bottom-0 left-8 z-10 hidden md:inline-flex"
         />
-        <h1 className="mx-auto max-w-5xl font-display text-[length:clamp(3rem,9vw,9rem)] leading-[0.9] font-semibold tracking-[-0.02em] text-white/90">
-          <span className="block">Your money,</span>
-          <span className="block">finally under control.</span>
-        </h1>
+        <AnimatedHeroTitle lines={["Your money,", "finally under control."]} />
       </div>
 
-      <p className="mx-auto mt-8 max-w-2xl text-lg leading-[1.6] text-muted">
+      <p
+        className="bi-rise mx-auto mt-8 max-w-2xl text-lg leading-[1.6] text-muted"
+        style={{ animationDelay: "900ms" }}
+      >
         BudgetIQ is a free, open-source personal finance app. Track income,
         expenses, and assets — and let the AI assistant log them straight from
         your words. Sign in with Google in seconds.
@@ -83,25 +100,34 @@ export default function LandingHero() {
       <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
         <Link
           href="/login"
-          className="inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-accent-bright"
+          className="group inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-base font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 hover:bg-accent-bright hover:shadow-[0_12px_32px_-8px_rgba(0,153,255,0.55)] active:translate-y-0 motion-reduce:hover:transform-none"
         >
           Get started free
-          <ArrowRight aria-hidden="true" className="h-4 w-4" />
+          <ArrowRight
+            aria-hidden="true"
+            className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1 motion-reduce:group-hover:translate-x-0"
+          />
         </Link>
         <a
           href="https://github.com/AmineMabrouk17/BudgetIQ"
-          className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
+          className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-[#010D1F] transition-all duration-300 hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-xl active:translate-y-0 motion-reduce:hover:transform-none"
         >
           <GithubIcon />
           View on GitHub
         </a>
       </div>
 
-      <p className="mt-14 text-[13px] uppercase tracking-[0.01em] text-muted">
+      <p
+        className="bi-rise mt-14 text-[13px] uppercase tracking-[0.01em] text-muted"
+        style={{ animationDelay: "1100ms" }}
+      >
         Free forever · Open source · No ads · Your data, yours
       </p>
 
-      <div className="mx-auto mt-16 w-full max-w-xl">
+      <div
+        className="bi-rise mx-auto mt-16 w-full max-w-xl"
+        style={{ animationDelay: "1200ms" }}
+      >
         <HeroMockup />
       </div>
     </section>

--- a/components/landing/LandingNav.tsx
+++ b/components/landing/LandingNav.tsx
@@ -28,7 +28,7 @@ export default function LandingNav() {
             <a
               key={href}
               href={href}
-              className="text-sm font-medium text-muted transition-colors hover:text-white/90"
+              className="relative text-sm font-medium text-muted transition-colors hover:text-white/90 after:absolute after:-bottom-1 after:left-0 after:h-px after:w-0 after:bg-current after:transition-all after:duration-300 hover:after:w-full motion-reduce:after:hidden"
             >
               {label}
             </a>
@@ -43,7 +43,7 @@ export default function LandingNav() {
           </Link>
           <Link
             href="/login"
-            className="inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-[#010D1F] transition-colors hover:bg-white/90"
+            className="group inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-[#010D1F] transition-all duration-300 hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-xl active:translate-y-0 motion-reduce:hover:transform-none"
           >
             Get started
           </Link>

--- a/components/landing/Parallax.test.tsx
+++ b/components/landing/Parallax.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Parallax from "@/components/landing/Parallax";
+
+describe("Parallax", () => {
+  it("renders children inside a translated wrapper", () => {
+    render(
+      <Parallax speed={0.2} className="test-class">
+        <div>Glow layer</div>
+      </Parallax>
+    );
+
+    const inner = screen.getByText("Glow layer");
+    const wrapper = inner.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveClass("test-class");
+  });
+});

--- a/components/landing/Parallax.tsx
+++ b/components/landing/Parallax.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface ParallaxProps {
+  children: ReactNode;
+  speed?: number;
+  className?: string;
+}
+
+export default function Parallax({
+  children,
+  speed = 0.15,
+  className,
+}: ParallaxProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mediaQuery.matches) return;
+
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      const rect = element.getBoundingClientRect();
+      const viewportCenter = window.innerHeight / 2;
+      const offset = (rect.top + rect.height / 2 - viewportCenter) * speed;
+      element.style.transform = `translate3d(0, ${offset.toFixed(1)}px, 0)`;
+    };
+
+    const onScroll = () => {
+      if (!frame) {
+        frame = window.requestAnimationFrame(update);
+      }
+    };
+
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [speed]);
+
+  return <div ref={ref} className={className}>{children}</div>;
+}

--- a/components/landing/PillTag.tsx
+++ b/components/landing/PillTag.tsx
@@ -3,6 +3,7 @@ interface PillTagProps {
   label: string;
   colorClass: string;
   rotationDeg: number;
+  popDelay?: number;
   className?: string;
 }
 
@@ -11,19 +12,30 @@ export default function PillTag({
   label,
   colorClass,
   rotationDeg,
+  popDelay = 700,
   className,
 }: PillTagProps) {
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold text-[#010D1F] shadow-lg ${colorClass} ${className ?? ""}`}
-      style={{
-        transform: `rotate(${rotationDeg}deg)`,
-        boxShadow:
-          "inset 0 1px 0 rgba(255,255,255,0.45), inset 0 -2px 4px rgba(0,0,0,0.15), 0 16px 32px -12px rgba(0,0,0,0.55)",
-      }}
+      className={`bi-float ${className ?? ""}`}
+      style={{ animationDelay: `${popDelay + 600}ms` }}
     >
-      <span aria-hidden="true">{emoji}</span>
-      {label}
+      <span
+        className="bi-pop block"
+        style={{ animationDelay: `${popDelay}ms` }}
+      >
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-semibold text-[#010D1F] shadow-lg ${colorClass}`}
+          style={{
+            transform: `rotate(${rotationDeg}deg)`,
+            boxShadow:
+              "inset 0 1px 0 rgba(255,255,255,0.45), inset 0 -2px 4px rgba(0,0,0,0.15), 0 16px 32px -12px rgba(0,0,0,0.55)",
+          }}
+        >
+          <span aria-hidden="true">{emoji}</span>
+          {label}
+        </span>
+      </span>
     </span>
   );
 }

--- a/components/landing/Reveal.test.tsx
+++ b/components/landing/Reveal.test.tsx
@@ -84,4 +84,26 @@ describe("Reveal", () => {
     expect(screen.getByText("Static content")).toHaveClass("opacity-100");
     expect(MockIntersectionObserver.instances).toHaveLength(0);
   });
+
+  it("applies the variant transform classes when revealing", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      createMatchMedia({ "(prefers-reduced-motion: reduce)": false })
+    );
+
+    render(
+      <Reveal variant="scale" delay={150}>
+        Scaled content
+      </Reveal>
+    );
+
+    const content = screen.getByText("Scaled content");
+    expect(content).toHaveClass("opacity-0");
+    expect(content).toHaveClass("scale-95");
+
+    act(() => MockIntersectionObserver.instances[0].trigger(true));
+
+    expect(content).toHaveClass("opacity-100");
+    expect(content).toHaveClass("scale-100");
+  });
 });

--- a/components/landing/Reveal.tsx
+++ b/components/landing/Reveal.tsx
@@ -24,11 +24,37 @@ function getServerSnapshot(): boolean {
   return false;
 }
 
+type RevealVariant = "up" | "fade" | "left" | "right" | "scale";
+
+const HIDDEN_CLASSES: Record<RevealVariant, string> = {
+  up: "opacity-0 translate-y-8",
+  fade: "opacity-0",
+  left: "opacity-0 -translate-x-8",
+  right: "opacity-0 translate-x-8",
+  scale: "opacity-0 scale-95",
+};
+
+const VISIBLE_CLASSES: Record<RevealVariant, string> = {
+  up: "opacity-100 translate-y-0",
+  fade: "opacity-100",
+  left: "opacity-100 translate-x-0",
+  right: "opacity-100 translate-x-0",
+  scale: "opacity-100 scale-100",
+};
+
 interface RevealProps {
   children: ReactNode;
+  variant?: RevealVariant;
+  delay?: number;
+  className?: string;
 }
 
-export default function Reveal({ children }: RevealProps) {
+export default function Reveal({
+  children,
+  variant = "up",
+  delay = 0,
+  className,
+}: RevealProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
   const reduced = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
@@ -60,9 +86,12 @@ export default function Reveal({ children }: RevealProps) {
   return (
     <div
       ref={ref}
+      style={delay && !reduced ? { transitionDelay: `${delay}ms` } : undefined}
       className={`${
-        isVisible ? "opacity-100" : "opacity-0"
-      } ${reduced ? "" : "transition-opacity duration-700 ease-out"}`}
+        isVisible ? VISIBLE_CLASSES[variant] : HIDDEN_CLASSES[variant]
+      } ${reduced ? "" : "transition-[opacity,transform] duration-700 ease-out"} ${
+        className ?? ""
+      }`}
     >
       {children}
     </div>

--- a/components/landing/SectionHeading.tsx
+++ b/components/landing/SectionHeading.tsx
@@ -1,3 +1,5 @@
+import Reveal from "@/components/landing/Reveal";
+
 interface SectionHeadingProps {
   eyebrow: string;
   title: string;
@@ -10,16 +12,18 @@ export default function SectionHeading({
   description,
 }: SectionHeadingProps) {
   return (
-    <div className="mx-auto max-w-2xl text-center">
-      <p className="text-[13px] uppercase tracking-[0.01em] text-muted">
-        {eyebrow}
-      </p>
-      <h2 className="mt-3 text-3xl font-display font-semibold tracking-[-0.02em] text-white/90 sm:text-4xl md:text-5xl">
-        {title}
-      </h2>
-      {description ? (
-        <p className="mt-4 leading-[1.6] text-muted">{description}</p>
-      ) : null}
-    </div>
+    <Reveal variant="up">
+      <div className="mx-auto max-w-2xl text-center">
+        <p className="text-[13px] uppercase tracking-[0.01em] text-muted">
+          {eyebrow}
+        </p>
+        <h2 className="mt-3 text-3xl font-display font-semibold tracking-[-0.02em] text-white/90 sm:text-4xl md:text-5xl">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-4 leading-[1.6] text-muted">{description}</p>
+        ) : null}
+      </div>
+    </Reveal>
   );
 }

--- a/components/landing/TestimonialsSection.tsx
+++ b/components/landing/TestimonialsSection.tsx
@@ -1,5 +1,6 @@
 import { Quote } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
+import Reveal from "@/components/landing/Reveal";
 
 interface TestimonialData {
   quote: string;
@@ -32,7 +33,7 @@ const testimonials: TestimonialData[] = [
 
 function TestimonialCard({ quote, name, role }: TestimonialData) {
   return (
-    <figure className="flex h-full flex-col rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg">
+    <figure className="group flex h-full flex-col rounded-2xl border border-white/[0.08] bg-night-raised p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-white/[0.18] hover:shadow-[0_24px_48px_-16px_rgba(0,0,0,0.55)] motion-reduce:hover:transform-none motion-reduce:transition-none">
       <Quote className="h-6 w-6 text-pop-yellow" aria-hidden="true" />
       <blockquote className="mt-4 flex-1 leading-[1.6] text-white/80">
         {quote}
@@ -55,8 +56,15 @@ export default function TestimonialsSection() {
           description="What early users say about BudgetIQ — real quotes coming soon."
         />
         <div className="mt-12 grid gap-6 md:grid-cols-3">
-          {testimonials.map((testimonial) => (
-            <TestimonialCard key={testimonial.name} {...testimonial} />
+          {testimonials.map((testimonial, index) => (
+            <Reveal
+              key={testimonial.name}
+              variant="up"
+              delay={index * 90}
+              className="h-full"
+            >
+              <TestimonialCard {...testimonial} />
+            </Reveal>
           ))}
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #58 / #59 (design system, merged). The motion commit landed on the feature branch after #59 merged, so this PR lands it cleanly on updated main. Cherry-picked as 2e53916 from 59464a6.

## Summary

Adds a full motion system to the landing page — load animations, scroll-triggered reveals, parallax depth, and hover micro-interactions — all disabled under `prefers-reduced-motion`.

## What's included

### Foundation (new infra)
- **`Reveal.tsx`** — upgraded with variants (`up`/`fade`/`left`/`right`/`scale`) and a stagger `delay` prop; still skips everything when `prefers-reduced-motion` is set
- **`Parallax.tsx`** (new) — rAF-throttled scroll-parallax wrapper (speed factor), reduced-motion aware
- **`globals.css`** — keyframe utilities `.bi-rise`, `.bi-pop`, `.bi-float`, `.bi-drift`, all killed under reduced motion

### Animations per area
1. **Typing/fade-in hero**: word-by-word headline reveal (`AnimatedHeroTitle`, pure CSS, SSR-safe, accessible name preserved); paragraph → CTAs → trust strip → mockup rise in sequence
2. **Scroll-triggered reveals**: every section heading + card staggers in via per-item `<Reveal delay={i*90}>` wrappers; page-level section wraps removed so cards reveal individually
3. **Interactive hover effects**: card lift with border/shadow depth on features/steps/testimonials/FAQ items; button lift with hover shadows
4. **Parallax scrolling**: hero glow layers move at ±different speeds; CTA band gets a drifting accent glow beneath the gradient card
5. **Micro-interactions**: pill tags spring-pop then float infinitely; arrow icon slides on CTA hover; icon chips scale; step numbers nudge; nav/footer links get underline-grow

## Verification
- vitest: **72/72 passing** (incl. new AnimatedHeroTitle + Parallax tests) on rebased base
- eslint: clean · tsc --noEmit: clean · next build: ✓ compiles

## Review notes
- Dev preview: `pnpm dev` → `/`; check hero load sequence, then scroll for reveals/parallax
- No copy, hrefs, or aria labels changed — existing assertions untouched
