### PR TITLE
perf: speed up landing page load

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,6 @@
 
 @theme inline {
   --font-sans: var(--font-inter);
-  --font-mono: var(--font-geist-mono);
   --font-display: var(--font-space-grotesk);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist_Mono, Inter, Space_Grotesk } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 import { cookies } from "next/headers";
 import "./globals.css";
 import { metadata as siteMetadata } from "./metadata";
@@ -15,11 +15,6 @@ const spaceGrotesk = Space_Grotesk({
   variable: "--font-space-grotesk",
   subsets: ["latin"],
   display: "swap",
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
 });
 
 export const metadata: Metadata = siteMetadata;
@@ -39,7 +34,7 @@ export default async function RootLayout({
       lang="en"
       data-theme={dataTheme}
       suppressHydrationWarning
-      className={`${inter.variable} ${spaceGrotesk.variable} ${geistMono.variable}`}
+      className={`${inter.variable} ${spaceGrotesk.variable}`}
     >
       <body>
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getProfile } from "@/lib/profiles";
-import { landingView } from "@/lib/landing-view";
+import { getUser } from "@/lib/supabase/server";
 import AnnouncementBar from "@/components/landing/AnnouncementBar";
 import LandingNav from "@/components/landing/LandingNav";
 import LandingHero from "@/components/landing/LandingHero";
@@ -12,9 +11,9 @@ import CtaBand from "@/components/landing/CtaBand";
 import LandingFooter from "@/components/landing/LandingFooter";
 
 export default async function Home() {
-  const profile = await getProfile();
+  const user = await getUser();
 
-  if (landingView(profile) === "dashboard") {
+  if (user) {
     redirect("/dashboard");
   }
 


### PR DESCRIPTION
## Summary
Reduce perceived load time on the landing page.

## Changes
- **app/page.tsx** — Drop the `profiles` DB round-trip ahead of the landing page. Unauthenticated visitors now hit a `getUser()` session check (singled network call the middleware already performs) instead of `getProfile()`, which also queried the `profiles` table. HTML streams to the client faster.
- **app/layout.tsx** — Remove the unused `Geist_Mono` web font from the root layout. No component references `font-mono`/`--font-geist-mono`, so this cuts an extra font file + variable setup from **every** route.
- **app/globals.css** — Drop the now-orphaned `--font-mono` mapping.

## Verification
- `pnpm run lint` — pass
- `pnpm tsc --noEmit` — pass
- `pnpm vitest run` — 72 tests pass
- `pnpm run build` — compiles, all routes generated