### PR TITLE
fix: reject client-supplied transaction id (always insert) (#65)

### DIFF
--- a/app/actions/transactions.ts
+++ b/app/actions/transactions.ts
@@ -42,7 +42,7 @@ function validateCreateInput(input: unknown):
     return { ok: false, error: "Invalid transaction payload." };
   }
 
-  const { type, title, amount, category, id } = input as Record<
+  const { type, title, amount, category } = input as Record<
     string,
     unknown
   >;
@@ -74,10 +74,6 @@ function validateCreateInput(input: unknown):
     return { ok: false, error: "Category must be 100 characters or fewer." };
   }
 
-  if (id !== undefined && (typeof id !== "string" || !UUID_REGEX.test(id))) {
-    return { ok: false, error: "Invalid transaction id." };
-  }
-
   return {
     ok: true,
     data: {
@@ -85,7 +81,6 @@ function validateCreateInput(input: unknown):
       title: title.trim(),
       amount: parsedAmount,
       category: trimmedCategory === "" ? undefined : trimmedCategory,
-      ...(typeof id === "string" ? { id } : {}),
     },
   };
 }

--- a/components/ai/TransactionActionCard.tsx
+++ b/components/ai/TransactionActionCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Check, Loader2, Plus } from "lucide-react";
 import type { ParsedTransactionAction } from "@/lib/gemini";
 import { createTransaction } from "@/app/actions/transactions";
@@ -19,7 +19,6 @@ export default function TransactionActionCard({
   action: ParsedTransactionAction;
 }) {
   const format = useCurrencyFormatter();
-  const idRef = useRef<string>(crypto.randomUUID());
   const [status, setStatus] = useState<"idle" | "added" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -35,7 +34,6 @@ export default function TransactionActionCard({
         title: action.title,
         amount: action.amount,
         category,
-        id: idRef.current,
       });
       if (result.ok) {
         setStatus("added");

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -58,16 +58,13 @@ export async function insertTransaction(
     title: input.title,
     amount: input.amount,
     category: input.category ?? "General",
-    ...(input.id ? { id: input.id } : {}),
   };
 
-  const query = input.id
-    ? supabase
-        .from("transactions")
-        .upsert(row, { onConflict: "id" })
-    : supabase.from("transactions").insert(row);
-
-  const { data, error } = await query.select().single();
+  const { data, error } = await supabase
+    .from("transactions")
+    .insert(row)
+    .select()
+    .single();
 
   if (error) throw error;
   return toTransaction(data);

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -15,5 +15,4 @@ export type CreateTransactionInput = {
   title: string;
   amount: number;
   category?: string;
-  id?: string;
 };


### PR DESCRIPTION
Closes #65

Removes the client-supplied id from createTransaction (validation, type, and the client component) and switches insertTransaction to always insert, letting Postgres generate the id. No more upsert-on-id, so a caller cannot overwrite an existing row.