### PR TITLE
fix: harden Gemini amount parsing + dashboard error boundaries (#66)

### DIFF
--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function DashboardError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center justify-center gap-4 p-6">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <span className="text-4xl text-error">
+          <AlertTriangle />
+        </span>
+        <h2 className="text-xl font-bold text-base-content">
+          Something went wrong
+        </h2>
+        <p className="text-sm text-base-content/70">
+          We couldn&apos;t load your dashboard. Please try again.
+        </p>
+        <button className="btn btn-primary" onClick={() => unstable_retry()}>
+          <RefreshCw />
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -1,0 +1,19 @@
+export default function DashboardLoading() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 p-6">
+      <header>
+        <div className="h-8 w-48 animate-pulse rounded bg-base-300" />
+      </header>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-lg bg-base-300"
+          />
+        ))}
+      </div>
+      <div className="h-72 animate-pulse rounded-lg bg-base-300" />
+      <div className="h-64 animate-pulse rounded-lg bg-base-300" />
+    </main>
+  );
+}

--- a/lib/gemini.test.ts
+++ b/lib/gemini.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseEnvelope } from "@/lib/gemini";
+
+describe("parseEnvelope amount parsing", () => {
+  function envelope(amount: unknown) {
+    return JSON.stringify({
+      message: "Got it",
+      hasAction: true,
+      transaction: {
+        type: "expense",
+        title: "Coffee",
+        amount,
+      },
+    });
+  }
+
+  it("accepts a plain positive number", () => {
+    const result = parseEnvelope(envelope(45));
+    expect(result.transaction?.amount).toBe(45);
+  });
+
+  it("accepts a decimal number", () => {
+    const result = parseEnvelope(envelope(12.5));
+    expect(result.transaction?.amount).toBe(12.5);
+  });
+
+  it("accepts a numeric string", () => {
+    const result = parseEnvelope(envelope("45"));
+    expect(result.transaction?.amount).toBe(45);
+  });
+
+  it("rejects a number with trailing characters (was 45abc -> 45)", () => {
+    expect(() => parseEnvelope(envelope("45abc"))).toThrow(
+      "invalid transaction amount"
+    );
+  });
+
+  it("rejects a zero amount", () => {
+    expect(() => parseEnvelope(envelope(0))).toThrow("invalid transaction amount");
+  });
+
+  it("rejects a negative amount", () => {
+    expect(() => parseEnvelope(envelope(-5))).toThrow("invalid transaction amount");
+  });
+
+  it("rejects a non-numeric string", () => {
+    expect(() => parseEnvelope(envelope("abc"))).toThrow(
+      "invalid transaction amount"
+    );
+  });
+});

--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 const INTERACTIONS_ENDPOINT =
   "https://generativelanguage.googleapis.com/v1beta/interactions";
 
@@ -30,11 +32,50 @@ export class GeminiApiError extends Error {
   }
 }
 
-const TRANSACTION_TYPES: readonly TransactionActionType[] = [
+const TRANSACTION_TYPES = [
   "income",
   "expense",
   "asset",
-];
+] as const satisfies readonly TransactionActionType[];
+
+const INVALID_AMOUNT = "Gemini response has an invalid transaction amount";
+
+const strictAmount = z
+  .union([z.number(), z.string()])
+  .transform((value, ctx): number => {
+    const text = typeof value === "number" ? String(value) : value.trim();
+    if (!/^\d+(\.\d+)?$/.test(text)) {
+      ctx.addIssue({ code: "custom", message: INVALID_AMOUNT });
+      return z.NEVER;
+    }
+    const amount = Number(text);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      ctx.addIssue({ code: "custom", message: INVALID_AMOUNT });
+      return z.NEVER;
+    }
+    return amount;
+  });
+
+const envelopeSchema = z.object({
+  message: z
+    .string()
+    .trim()
+    .min(1, { message: "Gemini response is missing a message" }),
+  hasAction: z.boolean(),
+  transaction: z
+    .object({
+      type: z.enum(TRANSACTION_TYPES, {
+        message: "Gemini response has an invalid transaction type",
+      }),
+      title: z
+        .string()
+        .trim()
+        .min(1, { message: "Gemini response is missing the transaction title" }),
+      amount: strictAmount,
+      category: z.string().trim().min(1).optional(),
+    })
+    .optional(),
+});
 
 const SYSTEM_PROMPT = `You are BudgetIQ, a friendly personal-finance assistant. Keep replies short and helpful.
 
@@ -74,58 +115,30 @@ export function parseEnvelope(raw: string): ChatActionResponse {
     throw new Error("Gemini returned invalid JSON");
   }
 
-  if (typeof data !== "object" || data === null) {
-    throw new Error("Gemini returned a non-object envelope");
+  const parsed = envelopeSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(
+      parsed.error.issues[0]?.message ?? "Gemini returned an invalid envelope"
+    );
   }
 
-  const record = data as Record<string, unknown>;
-  const message = typeof record.message === "string" ? record.message.trim() : "";
-  if (message.length === 0) {
-    throw new Error("Gemini response is missing a message");
-  }
-
-  if (record.hasAction !== true) {
+  const { message, hasAction, transaction } = parsed.data;
+  if (!hasAction) {
     return { message, hasAction: false };
   }
 
-  const transaction = record.transaction;
-  if (typeof transaction !== "object" || transaction === null) {
+  if (!transaction) {
     throw new Error("Gemini response is missing the transaction object");
   }
-
-  const t = transaction as Record<string, unknown>;
-  const type = t.type;
-  if (
-    typeof type !== "string" ||
-    !TRANSACTION_TYPES.includes(type as TransactionActionType)
-  ) {
-    throw new Error("Gemini response has an invalid transaction type");
-  }
-
-  const title = typeof t.title === "string" ? t.title.trim() : "";
-  if (title.length === 0) {
-    throw new Error("Gemini response is missing the transaction title");
-  }
-
-  const amount =
-    typeof t.amount === "number" ? t.amount : Number.parseFloat(String(t.amount));
-  if (!Number.isFinite(amount) || amount <= 0) {
-    throw new Error("Gemini response has an invalid transaction amount");
-  }
-
-  const category =
-    typeof t.category === "string" && t.category.trim().length > 0
-      ? t.category.trim()
-      : undefined;
 
   return {
     message,
     hasAction: true,
     transaction: {
-      type: type as TransactionActionType,
-      title,
-      amount,
-      ...(category ? { category } : {}),
+      type: transaction.type,
+      title: transaction.title,
+      amount: transaction.amount,
+      ...(transaction.category ? { category: transaction.category } : {}),
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "16.2.12",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "recharts": "^3.10.1"
+    "recharts": "^3.10.1",
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       recharts:
         specifier: ^3.10.1
         version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@playwright/test':
         specifier: ^1.62.1
@@ -2844,8 +2847,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
 snapshots:
 
@@ -4252,8 +4255,8 @@ snapshots:
       '@babel/parser': 7.29.8
       eslint: 9.39.5(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
+      zod: 4.5.4
+      zod-validation-error: 4.0.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -5680,8 +5683,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.4.3):
+  zod-validation-error@4.0.2(zod@4.5.4):
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
-  zod@4.4.3: {}
+  zod@4.5.4: {}


### PR DESCRIPTION
Closes #66

- Replaces manual chat-envelope validation in parseEnvelope with a zod schema.
- Strict amount parsing: reject trailing characters (45abc), non-finite, zero, and negative amounts; valid amounts pass.
- Adds app/(dashboard)/loading.tsx (skeleton) and error.tsx (message + retry via unstable_retry).