### PR TITLE
perf: paginate transactions + lazy-load CategoryChart (#67)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,12 +1,15 @@
-import { getTransactions } from "@/lib/transactions";
+import { getTransactions, getTransactionsPage } from "@/lib/transactions";
 import { computeSummary, groupExpensesByCategory } from "@/lib/summary";
 import SummaryCards from "@/components/dashboard/SummaryCards";
-import CategoryChart from "@/components/dashboard/CategoryChart";
+import LazyCategoryChart from "@/components/dashboard/LazyCategoryChart";
 import TransactionTable from "@/components/dashboard/TransactionTable";
 import ChatDrawer from "@/components/ai/ChatDrawer";
 
 export default async function DashboardPage() {
-  const transactions = await getTransactions();
+  const [transactions, page] = await Promise.all([
+    getTransactions(),
+    getTransactionsPage(),
+  ]);
   const summary = computeSummary(transactions);
   const categories = groupExpensesByCategory(transactions);
 
@@ -20,8 +23,11 @@ export default async function DashboardPage() {
           summary={summary}
           hasTransactions={transactions.length > 0}
         />
-        <CategoryChart categories={categories} />
-        <TransactionTable transactions={transactions} />
+        <LazyCategoryChart categories={categories} />
+        <TransactionTable
+          transactions={page.transactions}
+          nextCursor={page.nextCursor}
+        />
       </main>
     </ChatDrawer>
   );

--- a/app/actions/transactions.ts
+++ b/app/actions/transactions.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { insertTransaction, removeTransaction } from "@/lib/transactions";
+import {
+  getTransactionsPage,
+  insertTransaction,
+  removeTransaction,
+} from "@/lib/transactions";
 import { canonicalizeCategory } from "@/lib/categories";
 import type {
   CreateTransactionInput,
@@ -15,6 +19,10 @@ export type CreateTransactionResult =
 
 export type DeleteTransactionResult =
   | { ok: true }
+  | { ok: false; error: string };
+
+export type LoadMoreTransactionsResult =
+  | { ok: true; transactions: Transaction[]; nextCursor: string | null }
   | { ok: false; error: string };
 
 const TRANSACTION_TYPES: readonly TransactionType[] = [
@@ -124,6 +132,25 @@ export async function deleteTransaction(
     await removeTransaction(id);
     revalidatePath("/dashboard");
     return { ok: true };
+  } catch (error) {
+    return { ok: false, error: errorMessage(error) };
+  }
+}
+
+export async function loadMoreTransactions(
+  cursor: string
+): Promise<LoadMoreTransactionsResult> {
+  if (typeof cursor !== "string" || cursor.length === 0 || cursor.length > 512) {
+    return { ok: false, error: "Invalid cursor." };
+  }
+
+  try {
+    const page = await getTransactionsPage(cursor);
+    return {
+      ok: true,
+      transactions: page.transactions,
+      nextCursor: page.nextCursor,
+    };
   } catch (error) {
     return { ok: false, error: errorMessage(error) };
   }

--- a/components/dashboard/LazyCategoryChart.tsx
+++ b/components/dashboard/LazyCategoryChart.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { CategoryTotal } from "@/lib/summary";
+
+const CategoryChart = dynamic(
+  () => import("@/components/dashboard/CategoryChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="card w-full bg-base-100 shadow">
+        <div className="card-body">
+          <div className="h-6 w-40 animate-pulse rounded bg-base-300" />
+          <div className="h-72 w-full animate-pulse rounded bg-base-300" />
+        </div>
+      </div>
+    ),
+  }
+);
+
+export default function LazyCategoryChart({
+  categories,
+}: {
+  categories: CategoryTotal[];
+}) {
+  return <CategoryChart categories={categories} />;
+}

--- a/components/dashboard/TransactionTable.tsx
+++ b/components/dashboard/TransactionTable.tsx
@@ -3,7 +3,10 @@
 import { useState, useTransition } from "react";
 import { Check, Loader2, Trash2, X } from "lucide-react";
 import type { Transaction, TransactionType } from "@/types/transaction";
-import { deleteTransaction } from "@/app/actions/transactions";
+import {
+  deleteTransaction,
+  loadMoreTransactions,
+} from "@/app/actions/transactions";
 import AddTransactionModal from "@/components/dashboard/AddTransactionModal";
 import { useCurrencyFormatter } from "@/lib/use-display-currency";
 
@@ -22,11 +25,16 @@ function formatDate(value: string): string {
 }
 
 export default function TransactionTable({
-  transactions,
+  transactions: initialTransactions,
+  nextCursor: initialCursor,
 }: {
   transactions: Transaction[];
+  nextCursor: string | null;
 }) {
   const format = useCurrencyFormatter();
+  const [transactions, setTransactions] =
+    useState<Transaction[]>(initialTransactions);
+  const [nextCursor, setNextCursor] = useState<string | null>(initialCursor);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -38,6 +46,21 @@ export default function TransactionTable({
         setError(result.error);
       }
       setConfirmId(null);
+    });
+  }
+
+  function handleLoadMore() {
+    if (!nextCursor) return;
+    const cursor = nextCursor;
+    setError(null);
+    startTransition(async () => {
+      const result = await loadMoreTransactions(cursor);
+      if (result.ok) {
+        setTransactions((prev) => [...prev, ...result.transactions]);
+        setNextCursor(result.nextCursor);
+      } else {
+        setError(result.error);
+      }
     });
   }
 
@@ -145,6 +168,18 @@ export default function TransactionTable({
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+        {nextCursor && (
+          <div className="flex justify-center pt-2">
+            <button
+              className="btn btn-outline btn-sm"
+              onClick={handleLoadMore}
+              disabled={isPending}
+            >
+              {isPending ? <Loader2 className="animate-spin" /> : null}
+              Load more
+            </button>
           </div>
         )}
       </div>

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -27,6 +27,36 @@ function toTransaction(row: TransactionRow): Transaction {
   };
 }
 
+export const TRANSACTION_PAGE_SIZE = 100;
+
+export type TransactionPage = {
+  transactions: Transaction[];
+  nextCursor: string | null;
+};
+
+type PageCursor = { created_at: string; id: string };
+
+function encodeCursor(cursor: PageCursor): string {
+  return Buffer.from(JSON.stringify(cursor)).toString("base64url");
+}
+
+function decodeCursor(raw: string): PageCursor {
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.created_at === "string" &&
+      typeof parsed.id === "string"
+    ) {
+      return parsed as PageCursor;
+    }
+  } catch {
+    // fall through to thrown error
+  }
+  throw new Error("Invalid transaction cursor");
+}
+
 export async function getTransactions(): Promise<Transaction[]> {
   const supabase = await createClient();
   const {
@@ -41,6 +71,49 @@ export async function getTransactions(): Promise<Transaction[]> {
 
   if (error) throw error;
   return (data ?? []).map(toTransaction);
+}
+
+export async function getTransactionsPage(
+  cursor?: string
+): Promise<TransactionPage> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+
+  let query = supabase
+    .from("transactions")
+    .select("id, user_id, type, title, amount, category, created_at")
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(TRANSACTION_PAGE_SIZE + 1);
+
+  if (cursor) {
+    const parsed = decodeCursor(cursor);
+    query = query.or(
+      `created_at.lt.${parsed.created_at},and(created_at.eq.${parsed.created_at},id.lt.${parsed.id})`
+    );
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const rows = data ?? [];
+  const hasMore = rows.length > TRANSACTION_PAGE_SIZE;
+  const pageRows = hasMore ? rows.slice(0, TRANSACTION_PAGE_SIZE) : rows;
+
+  const last = pageRows[pageRows.length - 1];
+  return {
+    transactions: pageRows.map(toTransaction),
+    nextCursor:
+      hasMore && last
+        ? encodeCursor({
+            created_at: last.created_at,
+            id: last.id,
+          })
+        : null,
+  };
 }
 
 export async function insertTransaction(


### PR DESCRIPTION
Closes #67

- Adds keyset-paginated getTransactionsPage (limit 100 + cursor) and a loadMoreTransactions server action.
- TransactionTable renders the first page and offers a Load more button instead of the full history.
- Lazy-loads CategoryChart via next/dynamic (ssr:false + skeleton) in a client wrapper, splitting the recharts chunk from the initial bundle.