### PR TITLE
feat: custom KPI schema & model (#89)

### DIFF
--- a/app/actions/profiles.ts
+++ b/app/actions/profiles.ts
@@ -7,6 +7,7 @@ import {
   updateIncomeProfileInDb,
   type IncomeType,
 } from "@/lib/profiles";
+import { seedDefaultKpis } from "@/lib/kpi";
 
 export type UpdateIncomeProfileResult =
   | { ok: true }
@@ -53,6 +54,7 @@ export async function updateIncomeProfile(
       ...(payday !== undefined && { payday }),
       ...(expected_income !== undefined && { expected_income }),
     });
+    await seedDefaultKpis(user.id);
     revalidatePath("/dashboard");
     return { ok: true };
   } catch (error) {

--- a/lib/kpi.ts
+++ b/lib/kpi.ts
@@ -1,0 +1,51 @@
+import { createClient } from "@/lib/supabase/server";
+import type { CreateCustomKPIInput } from "@/types/kpi";
+
+const DEFAULT_KPIS: CreateCustomKPIInput[] = [
+  {
+    title: "Income",
+    source_type: "income",
+    operation: "sum",
+    sort_order: 0,
+  },
+  {
+    title: "Tax Reserve 15%",
+    source_type: "expense",
+    operation: "percentage",
+    operand: 0.15,
+    sort_order: 1,
+  },
+  {
+    title: "Budget Remaining",
+    source_type: "expense",
+    operation: "budget_remaining",
+    operand: 600,
+    sort_order: 2,
+  },
+];
+
+export async function seedDefaultKpis(userId: string): Promise<void> {
+  const supabase = await createClient();
+
+  const { count } = await supabase
+    .from("custom_kpis")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  if (count && count > 0) return;
+
+  const rows = DEFAULT_KPIS.map((kpi) => ({
+    user_id: userId,
+    title: kpi.title,
+    source_type: kpi.source_type,
+    category_filter: kpi.category_filter ?? null,
+    scope: kpi.scope ?? "all",
+    timeframe: kpi.timeframe ?? "this_month",
+    operation: kpi.operation,
+    operand: kpi.operand ?? 1.0,
+    sort_order: kpi.sort_order ?? 0,
+  }));
+
+  const { error } = await supabase.from("custom_kpis").insert(rows);
+  if (error) throw error;
+}

--- a/supabase/migrations/0007_custom_kpis.sql
+++ b/supabase/migrations/0007_custom_kpis.sql
@@ -1,0 +1,23 @@
+-- Custom KPI cards: user-owned, formula-driven dashboard metrics.
+
+CREATE TABLE IF NOT EXISTS public.custom_kpis (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    title TEXT NOT NULL CHECK (char_length(title) <= 60),
+    source_type TEXT NOT NULL CHECK (source_type IN ('income', 'expense', 'balance', 'category')),
+    category_filter TEXT,
+    scope TEXT DEFAULT 'all' CHECK (scope IN ('all', 'personal', 'business')),
+    timeframe TEXT DEFAULT 'this_month' CHECK (timeframe IN ('this_month', 'last_month', 'last_30_days', 'year_to_date', 'all_time')),
+    operation TEXT NOT NULL CHECK (operation IN ('sum', 'percentage', 'budget_remaining')),
+    operand NUMERIC(12, 2) DEFAULT 1.0,
+    sort_order INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE public.custom_kpis ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own KPIs"
+    ON public.custom_kpis
+    FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);

--- a/types/kpi.ts
+++ b/types/kpi.ts
@@ -1,0 +1,34 @@
+export type KpiSource = "income" | "expense" | "balance" | "category";
+export type KpiScope = "all" | "personal" | "business";
+export type KpiTimeframe =
+  | "this_month"
+  | "last_month"
+  | "last_30_days"
+  | "year_to_date"
+  | "all_time";
+export type KpiOperation = "sum" | "percentage" | "budget_remaining";
+
+export type CustomKPI = {
+  id: string;
+  user_id: string;
+  title: string;
+  source_type: KpiSource;
+  category_filter: string | null;
+  scope: KpiScope;
+  timeframe: KpiTimeframe;
+  operation: KpiOperation;
+  operand: number;
+  sort_order: number;
+  created_at: string;
+};
+
+export type CreateCustomKPIInput = {
+  title: string;
+  source_type: KpiSource;
+  category_filter?: string | null;
+  scope?: KpiScope;
+  timeframe?: KpiTimeframe;
+  operation: KpiOperation;
+  operand?: number;
+  sort_order?: number;
+};


### PR DESCRIPTION
Implements #89.

- New migration `supabase/migrations/0007_custom_kpis.sql` with RLS + ownership policy.
- `CustomKPI` type in `types/kpi.ts` (note: issue mentioned `lib/types.ts` which does not exist in this repo; types/ is the canonical home).
- Seed helper `lib/kpi.ts` creating 3 template KPI cards on onboarding completion.

## Scope
- migration: `supabase/migrations/0007_custom_kpis.sql`
- model: `types/kpi.ts`
- seed wiring: `app/actions/profiles.ts`, `lib/kpi.ts`