### PR TITLE
fix: remove deprecated quote landing copy (#98)

### DIFF
--- a/components/landing/FaqSection.tsx
+++ b/components/landing/FaqSection.tsx
@@ -36,7 +36,7 @@ const faqs: FaqData[] = [
   {
     question: "How is BudgetIQ different from other finance apps?",
     answer:
-      "AI-assisted logging from plain language, real-time net balance and asset tracking, daily financial quotes, and a fully open-source codebase — all free with no ads.",
+      "AI-assisted logging from plain language, real-time net balance and asset tracking, tailored KPI cards, and a fully open-source codebase — all free with no ads.",
   },
 ];
 

--- a/components/landing/FeaturesSection.test.tsx
+++ b/components/landing/FeaturesSection.test.tsx
@@ -21,7 +21,7 @@ describe("FeaturesSection", () => {
       "Log transactions by typing",
       "Know your numbers in real time",
       "See where your money goes",
-      "A fresh quote every day",
+      "Custom KPI cards that fit your life",
       "One-click sign-in, open source",
     ];
 

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -2,9 +2,9 @@ import type { LucideIcon } from "lucide-react";
 import {
   ChartPie,
   Gauge,
+  LayoutDashboard,
   LogIn,
   MessageSquare,
-  Quote,
   Receipt,
 } from "lucide-react";
 import SectionHeading from "@/components/landing/SectionHeading";
@@ -56,11 +56,11 @@ const featureCards: FeatureCardData[] = [
       "Interactive category breakdowns and charts turn your habits into something you can act on.",
   },
   {
-    icon: Quote,
+    icon: LayoutDashboard,
     color: "yellow",
-    title: "A fresh quote every day",
+    title: "Custom KPI cards that fit your life",
     description:
-      "Daily financial quotes keep you grounded and motivated, right inside the app.",
+      "Net balance, savings rate, profit, and runway — tailored cards for salaried, freelance, and business finances.",
   },
   {
     icon: LogIn,


### PR DESCRIPTION
Implements #98.

- Removed the quotes feature card ("A fresh quote every day") and replaced it with an accurate "Custom KPI cards" card reflecting the shipped per-persona dashboard (salaried/freelance/business).
- Removed the deprecated quotes copy from the landing FAQ answer.
- Repo-wide grep shows only legitimate/related uses remain (the `Quote` icon used as the quotation glyph in testimonials, and testimonial quote fields).
- Landing tests updated; typecheck, lint, and the full test suite pass.