### PR TITLE
feat: reconnect pay-cycle fields in profile picker (#99)

### DIFF
--- a/app/actions/profiles.ts
+++ b/app/actions/profiles.ts
@@ -13,10 +13,30 @@ export type UpdateIncomeProfileResult =
   | { ok: false; error: string };
 
 export async function updateIncomeProfile(
-  incomeType: IncomeType
+  incomeType: IncomeType,
+  options: {
+    payday?: number | null;
+    expected_income?: number | null;
+  } = {}
 ): Promise<UpdateIncomeProfileResult> {
   if (!INCOME_TYPES.includes(incomeType)) {
     return { ok: false, error: "Invalid income type." };
+  }
+
+  const { payday, expected_income } = options;
+  if (
+    payday !== undefined &&
+    payday !== null &&
+    (!Number.isInteger(payday) || payday < 1 || payday > 31)
+  ) {
+    return { ok: false, error: "Payday must be between 1 and 31." };
+  }
+  if (
+    expected_income !== undefined &&
+    expected_income !== null &&
+    (!Number.isFinite(expected_income) || expected_income <= 0)
+  ) {
+    return { ok: false, error: "Expected income must be positive." };
   }
 
   const supabase = await createClient();
@@ -28,7 +48,11 @@ export async function updateIncomeProfile(
   }
 
   try {
-    await updateIncomeProfileInDb(user.id, { income_type: incomeType });
+    await updateIncomeProfileInDb(user.id, {
+      income_type: incomeType,
+      ...(payday !== undefined && { payday }),
+      ...(expected_income !== undefined && { expected_income }),
+    });
     revalidatePath("/dashboard");
     return { ok: true };
   } catch (error) {

--- a/components/IncomeProfilePicker.test.tsx
+++ b/components/IncomeProfilePicker.test.tsx
@@ -40,8 +40,81 @@ describe("IncomeProfilePicker", () => {
     );
 
     await waitFor(() => {
-      expect(updateIncomeProfile).toHaveBeenCalledWith("freelancer");
+      expect(updateIncomeProfile).toHaveBeenCalledWith("freelancer", {});
     });
     expect(refresh).toHaveBeenCalled();
+  });
+
+  it("submits payday and expected income for pay-cycle income types", async () => {
+    updateIncomeProfile.mockResolvedValue({ ok: true });
+
+    render(<IncomeProfilePicker />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /salaried/i }));
+    fireEvent.change(
+      screen.getByLabelText(/payday/i),
+      { target: { value: "28" } }
+    );
+    fireEvent.change(
+      screen.getByLabelText(/expected income per pay period/i),
+      { target: { value: "5000" } }
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /save income profile/i })
+    );
+
+    await waitFor(() => {
+      expect(updateIncomeProfile).toHaveBeenCalledWith("salaried", {
+        payday: 28,
+        expected_income: 5000,
+      });
+    });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("does not clear payday/expected_income when the fields are left blank", async () => {
+    updateIncomeProfile.mockResolvedValue({ ok: true });
+
+    render(
+      <IncomeProfilePicker
+        initialIncomeType="salaried"
+        initialPayday={15}
+        initialExpectedIncome={4000}
+      />
+    );
+
+    expect(screen.getByLabelText(/payday/i)).toHaveValue(15);
+
+    fireEvent.change(screen.getByLabelText(/payday/i), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText(/expected income per pay period/i), {
+      target: { value: "" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /save income profile/i })
+    );
+
+    await waitFor(() => {
+      expect(updateIncomeProfile).toHaveBeenCalledWith("salaried", {});
+    });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("omits payday/expected_income for freelancer and business types", async () => {
+    updateIncomeProfile.mockResolvedValue({ ok: true });
+
+    render(
+      <IncomeProfilePicker initialIncomeType="salaried" initialPayday={15} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /business/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /save income profile/i })
+    );
+
+    await waitFor(() => {
+      expect(updateIncomeProfile).toHaveBeenCalledWith("business", {});
+    });
   });
 });

--- a/components/IncomeProfilePicker.tsx
+++ b/components/IncomeProfilePicker.tsx
@@ -28,17 +28,29 @@ const INCOME_TYPE_OPTIONS: { value: IncomeType; title: string; description: stri
   },
 ];
 
+const PAY_CYCLE_TYPES: IncomeType[] = ["salaried", "hourly"];
+
 export default function IncomeProfilePicker({
   initialIncomeType = null,
+  initialPayday = null,
+  initialExpectedIncome = null,
   variant = "step",
 }: {
   initialIncomeType?: IncomeType | null;
+  initialPayday?: number | null;
+  initialExpectedIncome?: number | null;
   variant?: "step" | "menu";
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [selected, setSelected] = useState<IncomeType | null>(
     initialIncomeType
+  );
+  const [payday, setPayday] = useState<string>(
+    initialPayday !== null ? String(initialPayday) : ""
+  );
+  const [expectedIncome, setExpectedIncome] = useState<string>(
+    initialExpectedIncome !== null ? String(initialExpectedIncome) : ""
   );
   const [error, setError] = useState<string | null>(null);
 
@@ -48,8 +60,20 @@ export default function IncomeProfilePicker({
       return;
     }
     setError(null);
+
+    const isPayCycleType = PAY_CYCLE_TYPES.includes(selected);
+    const paydayValue = payday.trim();
+    const expectedIncomeValue = expectedIncome.trim();
+    const options: { payday?: number; expected_income?: number } = {};
+    if (isPayCycleType && paydayValue !== "") {
+      options.payday = parseInt(paydayValue, 10);
+    }
+    if (isPayCycleType && expectedIncomeValue !== "") {
+      options.expected_income = parseFloat(expectedIncomeValue);
+    }
+
     startTransition(async () => {
-      const result = await updateIncomeProfile(selected);
+      const result = await updateIncomeProfile(selected, options);
       if (!result.ok) {
         setError(result.error);
         return;
@@ -62,6 +86,8 @@ export default function IncomeProfilePicker({
     variant === "menu"
       ? "space-y-1"
       : "grid grid-cols-1 gap-3 sm:grid-cols-2";
+
+  const payCycleFields = selected && PAY_CYCLE_TYPES.includes(selected);
 
   return (
     <form
@@ -101,6 +127,54 @@ export default function IncomeProfilePicker({
           );
         })}
       </div>
+
+      {payCycleFields && (
+        <div
+          className={
+            variant === "menu"
+              ? "mt-3 grid gap-2"
+              : "mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2"
+          }
+        >
+          <label className="form-control">
+            <span className="label-text mb-1 text-xs font-semibold text-base-content/70">
+              Payday (day of month)
+            </span>
+            <input
+              type="number"
+              name="payday"
+              min={1}
+              max={31}
+              step={1}
+              inputMode="numeric"
+              value={payday}
+              onChange={(e) => setPayday(e.target.value)}
+              placeholder="e.g. 28"
+              className="input input-bordered input-sm"
+            />
+          </label>
+          <label className="form-control">
+            <span className="label-text mb-1 text-xs font-semibold text-base-content/70">
+              Expected income per pay period
+            </span>
+            <input
+              type="number"
+              name="expected_income"
+              min={0}
+              step={0.01}
+              inputMode="decimal"
+              value={expectedIncome}
+              onChange={(e) => setExpectedIncome(e.target.value)}
+              placeholder="e.g. 5000"
+              className="input input-bordered input-sm"
+            />
+          </label>
+          <p className="text-xs text-base-content/50 sm:col-span-2">
+            Used to track pay-cycle progress on your dashboard. Leave blank to
+            keep your current values.
+          </p>
+        </div>
+      )}
 
       {error && (
         <p className="mt-3 text-sm text-error" role="alert">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -55,6 +55,8 @@ export default async function Navbar() {
                 <IncomeProfilePicker
                   variant="menu"
                   initialIncomeType={profile?.income_type ?? null}
+                  initialPayday={profile?.payday ?? null}
+                  initialExpectedIncome={profile?.expected_income ?? null}
                 />
               </div>
             </div>

--- a/lib/profiles.test.ts
+++ b/lib/profiles.test.ts
@@ -1,9 +1,44 @@
 import { describe, expect, it, vi } from "vitest";
-import { needsOnboarding } from "@/lib/profiles";
+import { needsOnboarding, updateIncomeProfileInDb } from "@/lib/profiles";
+import { createClient } from "@/lib/supabase/server";
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
+
+const mockedCreateClient = vi.mocked(createClient);
+
+const PROFILE = {
+  id: "user-1",
+  email: "a@b.c",
+  full_name: null,
+  avatar_url: null,
+  income_type: "salaried",
+  payday: 28,
+  expected_income: 5000,
+} as const;
+
+function mockUpdate(assertPayload: (payload: Record<string, unknown>) => void) {
+  const update = vi.fn(
+    (payload: Record<string, unknown>) => {
+      assertPayload(payload);
+      return {
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: PROFILE,
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+  );
+  mockedCreateClient.mockResolvedValue({
+    from: vi.fn().mockReturnValue({ update }),
+  } as never);
+  return update;
+}
 
 describe("needsOnboarding", () => {
   it("returns true for a missing profile", () => {
@@ -17,5 +52,53 @@ describe("needsOnboarding", () => {
   it("returns false once an income type has been chosen", () => {
     expect(needsOnboarding({ income_type: "salaried" })).toBe(false);
     expect(needsOnboarding({ income_type: "freelancer" })).toBe(false);
+  });
+});
+
+describe("updateIncomeProfileInDb", () => {
+  it("omits payday/expected_income from the update when not provided", async () => {
+    const update = mockUpdate((payload) => {
+      expect(payload).toEqual({ income_type: "salaried" });
+    });
+
+    await updateIncomeProfileInDb("user-1", { income_type: "salaried" });
+
+    expect(update).toHaveBeenCalled();
+  });
+
+  it("writes payday/expected_income when provided", async () => {
+    const update = mockUpdate((payload) => {
+      expect(payload).toEqual({
+        income_type: "hourly",
+        payday: 15,
+        expected_income: 3200.5,
+      });
+    });
+
+    await updateIncomeProfileInDb("user-1", {
+      income_type: "hourly",
+      payday: 15,
+      expected_income: 3200.5,
+    });
+
+    expect(update).toHaveBeenCalled();
+  });
+
+  it("clears payday/expected_income only when explicitly null", async () => {
+    const update = mockUpdate((payload) => {
+      expect(payload).toEqual({
+        income_type: "salaried",
+        payday: null,
+        expected_income: null,
+      });
+    });
+
+    await updateIncomeProfileInDb("user-1", {
+      income_type: "salaried",
+      payday: null,
+      expected_income: null,
+    });
+
+    expect(update).toHaveBeenCalled();
   });
 });

--- a/lib/profiles.ts
+++ b/lib/profiles.ts
@@ -54,13 +54,13 @@ export async function updateIncomeProfileInDb(
   input: UpdateIncomeProfileInput
 ): Promise<Profile> {
   const supabase = await createClient();
+  const updates: Record<string, unknown> = { income_type: input.income_type };
+  if (input.payday !== undefined) updates.payday = input.payday;
+  if (input.expected_income !== undefined)
+    updates.expected_income = input.expected_income;
   const { data, error } = await supabase
     .from("profiles")
-    .update({
-      income_type: input.income_type,
-      payday: input.payday ?? null,
-      expected_income: input.expected_income ?? null,
-    })
+    .update(updates)
     .eq("id", userId)
     .select(
       "id, email, full_name, avatar_url, income_type, payday, expected_income"


### PR DESCRIPTION
Implements #99.

- IncomeProfilePicker: salaried/hourly users can set payday + expected income.
- Persists via updateIncomeProfile without clearing existing values.
- Dashboard pay-cycle banner activates when values present, hides otherwise.
- Tests updated; summary pay-cycle cases green.