### PR TITLE
feat: title-to-category auto-suggestion (#93)

### DIFF
--- a/components/dashboard/AddTransactionModal.tsx
+++ b/components/dashboard/AddTransactionModal.tsx
@@ -5,6 +5,7 @@ import { Loader2, Plus } from "lucide-react";
 import { createTransaction } from "@/app/actions/transactions";
 import type { TransactionScope, TransactionType } from "@/types/transaction";
 import CategoryCombobox from "@/components/ui/CategoryCombobox";
+import { suggestCategory } from "@/lib/categories";
 
 const TYPES: { value: TransactionType; label: string }[] = [
   { value: "income", label: "Income" },
@@ -19,8 +20,10 @@ const SCOPES: { value: TransactionScope; label: string }[] = [
 
 export default function AddTransactionModal() {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [category, setCategory] = useState("");
 
   function open() {
     setError(null);
@@ -29,6 +32,14 @@ export default function AddTransactionModal() {
 
   function close() {
     dialogRef.current?.close();
+  }
+
+  function handleTitleBlur() {
+    if (category) return;
+    const title = titleRef.current?.value ?? "";
+    if (title.trim().length === 0) return;
+    const suggested = suggestCategory(title);
+    if (suggested) setCategory(suggested);
   }
 
   function handleSubmit(formData: FormData) {
@@ -72,12 +83,14 @@ export default function AddTransactionModal() {
             <label className="form-control w-full">
               <span className="label-text mb-1">Title</span>
               <input
+                ref={titleRef}
                 className="input input-bordered w-full"
                 type="text"
                 name="title"
                 placeholder="e.g. Groceries"
                 maxLength={255}
                 required
+                onBlur={handleTitleBlur}
               />
             </label>
             <label className="form-control w-full">
@@ -108,7 +121,7 @@ export default function AddTransactionModal() {
             </label>
             <label className="form-control w-full">
               <span className="label-text mb-1">Category</span>
-              <CategoryCombobox name="category" />
+              <CategoryCombobox name="category" value={category} />
             </label>
 
             {error && (

--- a/components/ui/CategoryCombobox.tsx
+++ b/components/ui/CategoryCombobox.tsx
@@ -19,9 +19,10 @@ import { getUserCategories } from "@/app/actions/transactions";
 type Props = {
   name: string;
   defaultValue?: string;
+  value?: string;
 };
 
-export default function CategoryCombobox({ name, defaultValue = "" }: Props) {
+export default function CategoryCombobox({ name, defaultValue = "", value }: Props) {
   const [query, setQuery] = useState(defaultValue);
   const [isOpen, setIsOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
@@ -33,6 +34,16 @@ export default function CategoryCombobox({ name, defaultValue = "" }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+
+  const [previousValue, setPreviousValue] = useState(value);
+
+  if (value !== previousValue) {
+    setPreviousValue(value);
+    if (value !== undefined) {
+      setSelected(value);
+      setQuery(value);
+    }
+  }
 
   useEffect(() => {
     startTransition(async () => {

--- a/lib/categories.test.ts
+++ b/lib/categories.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeCategory,
   titleCase,
   filterCategories,
+  suggestCategory,
   CATEGORY_PRESETS,
 } from "@/lib/categories";
 
@@ -86,5 +87,60 @@ describe("filterCategories", () => {
   it("returns empty array when nothing matches", () => {
     const result = filterCategories("zzzzz", history);
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("suggestCategory", () => {
+  const cases: { keyword: string; expected: string }[] = [
+    { keyword: "uber", expected: "Transportation" },
+    { keyword: "lyft", expected: "Transportation" },
+    { keyword: "gas", expected: "Transportation" },
+    { keyword: "netflix", expected: "Subscriptions" },
+    { keyword: "spotify", expected: "Subscriptions" },
+    { keyword: "rent", expected: "Housing & Rent" },
+    { keyword: "electric bill", expected: "Utilities & Bills" },
+    { keyword: "wifi", expected: "Utilities & Bills" },
+    { keyword: "groceries", expected: "Groceries" },
+    { keyword: "walmart", expected: "Groceries" },
+    { keyword: "restaurant", expected: "Food & Dining" },
+    { keyword: "starbucks", expected: "Food & Dining" },
+    { keyword: "movie", expected: "Entertainment & Leisure" },
+    { keyword: "pharmacy", expected: "Health & Medical" },
+    { keyword: "gym", expected: "Health & Medical" },
+    { keyword: "salary", expected: "Work & Business" },
+    { keyword: "invoice", expected: "Work & Business" },
+    { keyword: "amazon", expected: "Shopping & Other" },
+  ];
+
+  for (const { keyword, expected } of cases) {
+    it(`suggests "${expected}" for "${keyword}"`, () => {
+      expect(suggestCategory(keyword)).toBe(expected);
+    });
+  }
+
+  it("matches keywords substring-aware within a longer title", () => {
+    expect(suggestCategory("Uber ride to airport")).toBe("Transportation");
+    expect(suggestCategory("Netflix monthly subscription")).toBe(
+      "Subscriptions"
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(suggestCategory("UBER")).toBe("Transportation");
+    expect(suggestCategory("NetFlix")).toBe("Subscriptions");
+    expect(suggestCategory("WALMART")).toBe("Groceries");
+  });
+
+  it("returns null when no keyword matches", () => {
+    expect(suggestCategory("one-off gift from grandma")).toBeNull();
+    expect(suggestCategory("")).toBeNull();
+    expect(suggestCategory("   ")).toBeNull();
+  });
+
+  it("returns a preset label exactly as defined in CATEGORY_PRESETS", () => {
+    const presetLabels = CATEGORY_PRESETS.map((p) => p.label);
+    for (const { keyword } of cases) {
+      expect(presetLabels).toContain(suggestCategory(keyword));
+    }
   });
 });

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -61,3 +61,58 @@ export function filterCategories(
   if (q.length === 0) return allOptions;
   return allOptions.filter((cat) => cat.toLowerCase().includes(q));
 }
+
+const KEYWORD_MAP: { keywords: string[]; label: string }[] = [
+  {
+    keywords: ["uber", "lyft", "gas", "fuel", "transit", "metro", "bus", "taxi", "parking", "toll"],
+    label: "Transportation",
+  },
+  {
+    keywords: ["netflix", "spotify", "hulu", "disney", "subscription", "membership", "patreon"],
+    label: "Subscriptions",
+  },
+  {
+    keywords: ["rent", "mortgage", "apartment", "landlord", "hoa", "lease"],
+    label: "Housing & Rent",
+  },
+  {
+    keywords: ["electric", "electricity", "water", "internet", "wifi", "phone", "bill", "gas bill"],
+    label: "Utilities & Bills",
+  },
+  {
+    keywords: ["grocery", "groceries", "walmart", "costco", "trader joe", "whole foods", "aldi", "safeway"],
+    label: "Groceries",
+  },
+  {
+    keywords: ["restaurant", "food", "dining", "pizza", "burger", "coffee", "starbucks", "mcdonald", "chipotle", "doordash", "grubhub", "uber eats", "takeout", "lunch", "dinner", "breakfast"],
+    label: "Food & Dining",
+  },
+  {
+    keywords: ["movie", "cinema", "concert", "game", "steam", "psn", "xbox", "nintendo", "ticket", "show", "theater"],
+    label: "Entertainment & Leisure",
+  },
+  {
+    keywords: ["doctor", "hospital", "pharmacy", "medical", "health", "insurance", "dental", "vision", "therapy", "gym", "fitness"],
+    label: "Health & Medical",
+  },
+  {
+    keywords: ["salary", "invoice", "client", "office", "freelance", "business", "supplies", "software", "saas"],
+    label: "Work & Business",
+  },
+  {
+    keywords: ["amazon", "ebay", "shopping", "clothes", "clothing", "shoes", "target", "store", "purchase"],
+    label: "Shopping & Other",
+  },
+];
+
+export function suggestCategory(title: string): string | null {
+  const lower = title.toLowerCase();
+  for (const entry of KEYWORD_MAP) {
+    for (const keyword of entry.keywords) {
+      if (lower.includes(keyword)) {
+        return entry.label;
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Implements #93 (stacked on #92).

- suggestCategory(title) pure heuristic in lib/categories.ts + keyword mapping table.
- Wired into AddTransactionModal on title blur (empty category only).
- Extended lib/categories.test.ts.