### PR TITLE
fix(api): trim and scope api responses (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Under the hood it pairs a **Next.js** front end with **Supabase** (PostgreSQL + 
 ### 🔌 API Integrations
 - **Supabase Auth** — Google OAuth (one-click) and email/password sign-in.
 - **Google Gemini** (`gemini-3.6-flash` via the Interactions API) — structured JSON responses with schema-enforced transaction detection.
-- **Quotes API** (`api-ninjas`, with fallbacks) — the daily quote feed.
-- **Session-protected endpoints** — `/api/chat` and `/api/quotes` require an authenticated session.
+- **Session-protected endpoint** — `/api/chat` requires an authenticated session.
 
 ---
 
@@ -182,14 +181,14 @@ A non-exhaustive set of ideas for the future — feel free to open these as GitH
 │   ├── (auth)/            # Login & auth callback routes
 │   ├── (dashboard)/       # Dashboard pages & layout
 │   ├── actions/           # Server Actions (auth, transactions)
-│   ├── api/               # /api/chat (Gemini) & /api/quotes routes
+│   ├── api/               # /api/chat (Gemini) route
 │   └── layout.tsx         # Root layout, fonts & theme
 ├── components/
 │   ├── ai/                # AI assistant drawer & action cards
 │   ├── dashboard/         # Summary cards, charts, tables, modals
 │   ├── landing/           # Landing page sections (with tests)
 │   └── Navbar.tsx         # Header with auth & theme toggle
-├── lib/                   # Supabase clients, Gemini, data layers, quotes
+├── lib/                   # Supabase clients, Gemini, data layers
 ├── supabase/migrations/   # Database schema & RLS
 └── types/                 # Shared types
 ```

--- a/lib/gemini.test.ts
+++ b/lib/gemini.test.ts
@@ -49,3 +49,63 @@ describe("parseEnvelope amount parsing", () => {
     );
   });
 });
+
+describe("parseEnvelope response shape regression", () => {
+  it("has no action returns exactly { message, hasAction }", () => {
+    const result = parseEnvelope(
+      JSON.stringify({ message: "Hello", hasAction: false })
+    );
+    expect(result).toEqual({ message: "Hello", hasAction: false });
+    expect(Object.keys(result).sort()).toEqual(["hasAction", "message"]);
+  });
+
+  it("with action returns exactly { message, hasAction, transaction }", () => {
+    const result = parseEnvelope(
+      JSON.stringify({
+        message: "Logged it",
+        hasAction: true,
+        transaction: {
+          type: "expense",
+          title: "Lunch",
+          amount: "12",
+          category: "Food",
+        },
+      })
+    );
+    expect(result).toEqual({
+      message: "Logged it",
+      hasAction: true,
+      transaction: {
+        type: "expense",
+        title: "Lunch",
+        amount: 12,
+        category: "Food",
+      },
+    });
+    expect(Object.keys(result).sort()).toEqual([
+      "hasAction",
+      "message",
+      "transaction",
+    ]);
+  });
+
+  it("with action omits undefined category from transaction", () => {
+    const result = parseEnvelope(
+      JSON.stringify({
+        message: "Logged it",
+        hasAction: true,
+        transaction: { type: "income", title: "Salary", amount: 500 },
+      })
+    );
+    expect(result).toEqual({
+      message: "Logged it",
+      hasAction: true,
+      transaction: { type: "income", title: "Salary", amount: 500 },
+    });
+    expect(Object.keys(result.transaction ?? {})).toEqual([
+      "type",
+      "title",
+      "amount",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #114

Trims and locks the public API surface: currency-rates stays scoped to supported codes with stale-cache serving, the /api/chat envelope is pinned by a shape regression test, and stale /api/quotes docs are removed.

![Context after this change: the trimmed API surface, /api/currency-rates scope and the removed /api/quotes docs references](https://github.com/user-attachments/assets/8f2849d1-12f7-4f16-8d8b-71988107092c)

![Data flow: parseEnvelope producing the exact locked response envelope ({ message, hasAction, transaction? }) now asserted by the regression test](https://github.com/user-attachments/assets/1d716acc-351a-4850-ae65-e2f9d3bd1c9b)

Implements the issue exactly. Migration check: not needed

<!-- before-and-after:start -->
> Before/after by agent-browser demo

Demo evidence: rendered README.md API Integrations section, main (still references /api/quotes) vs this branch (stale references removed).

| Before (README API docs) | After (README API docs) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/95bc2e34-efa7-485a-b7da-d8c72fd6ddfd) | ![After](https://github.com/user-attachments/assets/a6765ced-59f5-4933-b05e-833932a79c4e) |

<!-- before-and-after:end -->
