### PR TITLE
feat(security): add app-level rate limiting (#111)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,3 +14,7 @@ API_NINJAS_API_KEY=your-api-ninjas-api-key
 # Cloudflare Turnstile bot protection (dash.cloudflare.com -> Turnstile)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
 TURNSTILE_SECRET_KEY=your-turnstile-secret-key
+
+# Upstash Rate Limiting (optional — falls back to in-memory when absent)
+UPSTASH_REDIS_REST_URL=https://your-upstash-redis-url
+UPSTASH_REDIS_REST_TOKEN=your-upstash-redis-token

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
 import { verifyTurnstile } from "@/app/actions/auth";
 import { Loader2, Globe, Mail, Send } from "lucide-react";
+import { checkLoginRateLimit } from "@/app/actions/auth";
 
 const TURNSTILE_SCRIPT_URL =
   "https://challenges.cloudflare.com/turnstile/v0/api.js";
@@ -239,6 +240,13 @@ export default function LoginPage() {
     if (!verification.ok) {
       setError(verification.error);
       resetTurnstile();
+      setPendingEmail(false);
+      return;
+    }
+
+    const limitCheck = await checkLoginRateLimit(email);
+    if (!limitCheck.ok) {
+      setError(limitCheck.error);
       setPendingEmail(false);
       return;
     }

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,8 +1,9 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { rateLimit } from "@/lib/rate-limit";
 
 export async function signOut() {
   const supabase = await createClient();
@@ -58,4 +59,40 @@ export async function verifyTurnstile(
       error: "Something went wrong on our end. Please try again in a moment.",
     };
   }
+}
+
+export async function checkLoginRateLimit(
+  email: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const headerStore = await headers();
+  const forwarded = headerStore.get("x-forwarded-for");
+  const ip = forwarded ? forwarded.split(",")[0].trim() : "unknown";
+
+  const perIp = await rateLimit({
+    prefix: "login-ip",
+    identifier: ip,
+    limit: 10,
+    window: 60,
+  });
+  if (!perIp.success) {
+    return {
+      ok: false,
+      error: "Too many attempts. Please wait a minute and try again.",
+    };
+  }
+
+  const perEmail = await rateLimit({
+    prefix: "login-email",
+    identifier: email.trim().toLowerCase(),
+    limit: 5,
+    window: 60,
+  });
+  if (!perEmail.success) {
+    return {
+      ok: false,
+      error: "Too many attempts. Please wait a minute and try again.",
+    };
+  }
+
+  return { ok: true };
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
 import { askGemini, GeminiApiError } from "@/lib/gemini";
+import { rateLimit } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
+
+const CHAT_RATE_LIMIT = 20;
+const CHAT_RATE_WINDOW = 60;
 
 const MAX_MESSAGE_LENGTH = 1000;
 
@@ -36,6 +40,19 @@ export async function POST(request: NextRequest) {
   const user = await getUser();
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rate = await rateLimit({
+    prefix: "chat",
+    identifier: user.id,
+    limit: CHAT_RATE_LIMIT,
+    window: CHAT_RATE_WINDOW,
+  });
+  if (!rate.success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded" },
+      { status: 429 }
+    );
   }
 
   let body: unknown;

--- a/app/api/currency-rates/route.ts
+++ b/app/api/currency-rates/route.ts
@@ -1,11 +1,36 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getRatesForDisplay } from "@/lib/currency/rates";
+import { rateLimit } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+const RATES_RATE_LIMIT = 30;
+const RATES_RATE_WINDOW = 60;
+
+function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+export async function GET(request: NextRequest) {
+  const rate = await rateLimit({
+    prefix: "currency-rates",
+    identifier: getClientIp(request),
+    limit: RATES_RATE_LIMIT,
+    window: RATES_RATE_WINDOW,
+  });
+  if (!rate.success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded" },
+      { status: 429 }
+    );
+  }
+
   const rates = await getRatesForDisplay();
   return NextResponse.json({ rates });
 }

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadRateLimit() {
+  vi.resetModules();
+  const { rateLimit } = await import("@/lib/rate-limit");
+  return rateLimit;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  vi.resetModules();
+});
+
+describe("rateLimit (in-memory fallback)", () => {
+  it("allows requests up to the limit and blocks on breach", async () => {
+    const rateLimit = await loadRateLimit();
+
+    const first = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 3,
+      window: 60,
+    });
+    expect(first.success).toBe(true);
+    expect(first.remaining).toBe(2);
+
+    const second = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 3,
+      window: 60,
+    });
+    expect(second.success).toBe(true);
+
+    const third = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 3,
+      window: 60,
+    });
+    expect(third.success).toBe(true);
+
+    const blocked = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 3,
+      window: 60,
+    });
+    expect(blocked.success).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
+  it("does not affect a different identifier", async () => {
+    const rateLimit = await loadRateLimit();
+
+    for (let i = 0; i < 4; i++) {
+      await rateLimit({
+        prefix: "test",
+        identifier: "user-1",
+        limit: 3,
+        window: 60,
+      });
+    }
+
+    const other = await rateLimit({
+      prefix: "test",
+      identifier: "user-2",
+      limit: 3,
+      window: 60,
+    });
+    expect(other.success).toBe(true);
+    expect(other.remaining).toBe(2);
+  });
+
+  it("resets the window after it elapses", async () => {
+    const rateLimit = await loadRateLimit();
+
+    for (let i = 0; i < 3; i++) {
+      await rateLimit({
+        prefix: "test",
+        identifier: "user-1",
+        limit: 2,
+        window: 60,
+      });
+    }
+
+    const blocked = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 2,
+      window: 60,
+    });
+    expect(blocked.success).toBe(false);
+
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 61_000);
+
+    const afterReset = await rateLimit({
+      prefix: "test",
+      identifier: "user-1",
+      limit: 2,
+      window: 60,
+    });
+    expect(afterReset.success).toBe(true);
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,77 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+export type RateLimitResult = {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+};
+
+type RateLimitOptions = {
+  prefix: string;
+  identifier: string;
+  limit: number;
+  window: number;
+};
+
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const hasRedis = Boolean(redisUrl && redisToken);
+
+const redisClient = hasRedis
+  ? new Redis({ url: redisUrl!, token: redisToken! })
+  : null;
+
+const redisLimiters = new Map<string, Ratelimit>();
+
+function getRedisLimiter({ prefix, limit, window }: RateLimitOptions): Ratelimit {
+  const key = `${prefix}:${limit}:${window}`;
+  let limiter = redisLimiters.get(key);
+  if (!limiter) {
+    limiter = new Ratelimit({
+      redis: redisClient!,
+      limiter: Ratelimit.slidingWindow(limit, `${window} s`),
+      prefix: `budgetiq:${prefix}`,
+    });
+    redisLimiters.set(key, limiter);
+  }
+  return limiter;
+}
+
+const memoryBuckets = new Map<string, { count: number; reset: number }>();
+
+function memoryRateLimit({
+  prefix,
+  identifier,
+  limit,
+  window,
+}: RateLimitOptions): RateLimitResult {
+  const now = Date.now();
+  const windowMs = window * 1000;
+  const key = `${prefix}:${identifier}`;
+  const current = memoryBuckets.get(key);
+  const reset = now + windowMs;
+
+  if (!current || current.reset <= now) {
+    memoryBuckets.set(key, { count: 1, reset });
+    return { success: true, limit, remaining: limit - 1, reset };
+  }
+
+  if (current.count >= limit) {
+    return { success: false, limit, remaining: 0, reset: current.reset };
+  }
+
+  current.count += 1;
+  return { success: true, limit, remaining: limit - current.count, reset };
+}
+
+export async function rateLimit(
+  options: RateLimitOptions
+): Promise<RateLimitResult> {
+  if (hasRedis && redisClient) {
+    return await getRedisLimiter(options).limit(options.identifier);
+  }
+  return memoryRateLimit(options);
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@supabase/ssr": "^0.12.4",
     "@supabase/supabase-js": "^2.111.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.4",
     "daisyui": "^5.7.14",
     "lucide-react": "^1.28.0",
     "next": "16.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.111.0
         version: 2.111.0
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.4)
+      '@upstash/redis':
+        specifier: ^1.38.4
+        version: 1.38.4
       daisyui:
         specifier: ^5.7.14
         version: 5.7.14
@@ -1038,6 +1044,18 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.4':
+    resolution: {integrity: sha512-ZX69mKReun/yieyHYLoBg0eSiF6hjCQjd8zUKkJ5eCHehDV6P8S8oZOHxGSfkH1spfOhGZk0EGerBrfUsXow8g==}
 
   '@vitejs/plugin-react@6.0.5':
     resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
@@ -2674,6 +2692,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -3690,6 +3711,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.4
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.4)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.4
+
+  '@upstash/redis@1.38.4':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@20.19.43)(jiti@2.7.0))':
     dependencies:
@@ -5533,6 +5567,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
Closes #111

Adds app-level rate limiting to the two paid/abuse-prone surfaces and the login gate, backed by Upstash Redis with an in-memory Map fallback when the Redis env vars are absent.

![Architecture after this change: rateLimit between the login action, /api/chat and /api/currency-rates and Upstash Redis (or the in-memory fallback)](https://github.com/user-attachments/assets/e3b7414a-ea9c-4c5e-8caa-74728b018513)

![Data flow: a login attempt gated per-IP and per-email before Supabase auth, and API requests returning 429 on breach](https://github.com/user-attachments/assets/0e3bc1c6-6f1c-46ba-b700-51040293c4f5)

Implements the issue exactly (@upstash/ratelimit + in-memory fallback, 429s on /api/chat and /api/currency-rates, friendly login limit).

Migration check: not needed. New env vars: UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN (set in .env.local and Vercel Preview/Production).

<!-- before-and-after:start -->
> Before/after by agent-browser demo

Demo evidence: 31 rapid GET requests to /api/currency-rates on a local dev server. Before (main) always returns 200 + rates JSON; after (this branch) returns 429 Rate limit exceeded on the 31st request via the in-memory fallback (Upstash env vars not present locally).

| Before (GET /api/currency-rates (31st request)) | After (GET /api/currency-rates (31st request)) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/9989ffb5-0075-48d1-9735-709b08a0f19a) | ![After](https://github.com/user-attachments/assets/6a16a0a7-f8b5-479f-b65b-010d9a5ec090) |

<!-- before-and-after:end -->
