### PR TITLE
feat(auth): add Cloudflare Turnstile bot protection (#112)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,7 @@ GEMINI_API_KEY=your-gemini-api-key
 
 # API Ninjas Quotes API Key (api-ninjas.com)
 API_NINJAS_API_KEY=your-api-ninjas-api-key
+
+# Cloudflare Turnstile bot protection (dash.cloudflare.com -> Turnstile)
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
+TURNSTILE_SECRET_KEY=your-turnstile-secret-key

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
+import { verifyTurnstile } from "@/app/actions/auth";
 import { Loader2, Globe, Mail, Send } from "lucide-react";
+
+const TURNSTILE_SCRIPT_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
 type Mode = "signin" | "signup";
 type ErrorAction = "switchToSignIn" | "switchToSignUp" | "resend" | null;
@@ -74,16 +80,100 @@ export default function LoginPage() {
   const [message, setMessage] = useState<string | null>(null);
   const [pendingOAuth, setPendingOAuth] = useState(false);
   const [pendingEmail, setPendingEmail] = useState(false);
+  const turnstileContainerRef = useRef<HTMLDivElement>(null);
+  const turnstileWidgetId = useRef<string | undefined>(undefined);
+  const turnstileTokenRef = useRef<string | null>(null);
   const searchParams = useSearchParams();
   const callbackError = searchParams.get("error");
 
   const supabase = createClient();
+
+  useEffect(() => {
+    if (!turnstileSiteKey) return;
+
+    const siteKey: string = turnstileSiteKey;
+    const container = turnstileContainerRef.current;
+    if (!container) return;
+
+    const widgetTarget: HTMLElement = container;
+
+    let cancelled = false;
+    turnstileTokenRef.current = null;
+
+    function renderWidget() {
+      if (cancelled || !window.turnstile) return;
+      if (turnstileWidgetId.current) {
+        try {
+          window.turnstile.remove(turnstileWidgetId.current);
+        } catch {
+          // The widget may already be gone (e.g. tab switch); render a fresh one.
+        }
+        turnstileWidgetId.current = undefined;
+      }
+      turnstileWidgetId.current = window.turnstile.render(widgetTarget, {
+        sitekey: siteKey,
+        action: "turnstile-spin-v2",
+        callback: (token) => {
+          turnstileTokenRef.current = token;
+        },
+        "expired-callback": () => {
+          turnstileTokenRef.current = null;
+        },
+      });
+    }
+
+    function loadScript() {
+      if (window.turnstile) {
+        renderWidget();
+        return;
+      }
+      const existing = document.querySelector<HTMLScriptElement>(
+        `script[src="${TURNSTILE_SCRIPT_URL}"]`
+      );
+      if (existing) {
+        existing.addEventListener("load", renderWidget, { once: true });
+        return;
+      }
+      const script = document.createElement("script");
+      script.src = TURNSTILE_SCRIPT_URL;
+      script.async = true;
+      script.defer = true;
+      script.addEventListener("load", renderWidget, { once: true });
+      document.head.appendChild(script);
+    }
+
+    loadScript();
+
+    return () => {
+      cancelled = true;
+      if (turnstileWidgetId.current && window.turnstile) {
+        try {
+          window.turnstile.remove(turnstileWidgetId.current);
+        } catch {
+          // ignore
+        }
+        turnstileWidgetId.current = undefined;
+      }
+    };
+  }, [mode]);
+
+  function resetTurnstile() {
+    turnstileTokenRef.current = null;
+    if (turnstileWidgetId.current && window.turnstile) {
+      try {
+        window.turnstile.reset(turnstileWidgetId.current);
+      } catch {
+        // ignore
+      }
+    }
+  }
 
   function switchMode(next: Mode) {
     setMode(next);
     setError(null);
     setErrorAction(null);
     setMessage(null);
+    resetTurnstile();
   }
 
   function applyError(error: AuthError) {
@@ -135,7 +225,23 @@ export default function LoginPage() {
     setError(null);
     setErrorAction(null);
     setMessage(null);
+
+    const turnstileTokenValue = turnstileTokenRef.current;
+    if (!turnstileTokenValue) {
+      setError("Please complete the security check before submitting.");
+      resetTurnstile();
+      return;
+    }
+
     setPendingEmail(true);
+
+    const verification = await verifyTurnstile(turnstileTokenValue);
+    if (!verification.ok) {
+      setError(verification.error);
+      resetTurnstile();
+      setPendingEmail(false);
+      return;
+    }
 
     if (mode === "signup") {
       const { data, error } = await supabase.auth.signUp({
@@ -184,6 +290,7 @@ export default function LoginPage() {
     }
 
     setPendingEmail(false);
+    resetTurnstile();
   }
 
   return (
@@ -274,6 +381,13 @@ export default function LoginPage() {
               autoComplete={mode === "signup" ? "new-password" : "current-password"}
             />
           </label>
+          {turnstileSiteKey && (
+            <div
+              key={mode}
+              ref={turnstileContainerRef}
+              className="mt-1 flex min-h-[65px] justify-center"
+            />
+          )}
           <button
             className="btn btn-primary mt-2"
             disabled={pendingEmail || pendingOAuth}

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,10 +1,61 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 
 export async function signOut() {
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect("/");
+}
+
+export type VerifyTurnstileResult = { ok: true } | { ok: false; error: string };
+
+const TURNSTILE_SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const TURNSTILE_FAILURE_MESSAGE =
+  "Security check failed. Please confirm you are not a robot and try again.";
+
+export async function verifyTurnstile(
+  token: string
+): Promise<VerifyTurnstileResult> {
+  if (!token) {
+    return { ok: false, error: TURNSTILE_FAILURE_MESSAGE };
+  }
+
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) {
+    return {
+      ok: false,
+      error: "Bot protection isn't configured yet. Please try again later.",
+    };
+  }
+
+  try {
+    const requestHeaders = await headers();
+    const forwardedFor = requestHeaders.get("x-forwarded-for");
+    const remoteip = forwardedFor?.split(",")[0]?.trim() || undefined;
+
+    const formBody = new URLSearchParams({ secret, response: token });
+    if (remoteip) formBody.set("remoteip", remoteip);
+
+    const response = await fetch(TURNSTILE_SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody,
+    });
+
+    const result = (await response.json()) as { success?: boolean };
+    if (!result.success) {
+      return { ok: false, error: TURNSTILE_FAILURE_MESSAGE };
+    }
+
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      error: "Something went wrong on our end. Please try again in a moment.",
+    };
+  }
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -11,15 +11,16 @@ const supabaseWssUrl = `wss://${supabaseOrigin.host}`;
 function contentSecurityPolicy(nonce: string): string {
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://challenges.cloudflare.com${isDev ? " 'unsafe-eval'" : ""}`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' blob: data: https://*.googleusercontent.com",
     "font-src 'self'",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
+    "frame-src https://challenges.cloudflare.com",
     "frame-ancestors 'self'",
-    `connect-src 'self' ${supabaseOrigin.origin} ${supabaseWssUrl}`,
+    `connect-src 'self' ${supabaseOrigin.origin} ${supabaseWssUrl} https://challenges.cloudflare.com`,
     "upgrade-insecure-requests",
   ].join("; ");
 }

--- a/types/turnstile.d.ts
+++ b/types/turnstile.d.ts
@@ -1,0 +1,20 @@
+interface TurnstileRenderOptions {
+  sitekey: string;
+  action?: string;
+  callback?: (token: string) => void;
+  "expired-callback"?: () => void;
+  "error-callback"?: () => void;
+}
+
+interface Turnstile {
+  render: (
+    container: HTMLElement,
+    options: TurnstileRenderOptions
+  ) => string;
+  reset: (widgetId?: string | HTMLElement) => void;
+  remove: (widgetId: string | HTMLElement) => void;
+}
+
+interface Window {
+  turnstile?: Turnstile;
+}


### PR DESCRIPTION
Closes #112

Adds Cloudflare Turnstile bot protection to sign-in and sign-up: an explicit-render widget on both tabs plus server-side siteverify that blocks auth when the token is missing or invalid.

![Architecture after this change: the Turnstile widget on the login form verified server-side via siteverify before Supabase auth proceeds](https://github.com/user-attachments/assets/054991c8-8306-43c2-9779-1accc84a416e)

![Data flow: submitting the login form, the Turnstile token going through siteverify, blocking or allowing the Supabase auth call](https://github.com/user-attachments/assets/cb28145d-76fc-478f-b8f8-d156dc4b1fce)

Implements the issue exactly (widget + server-side siteverify + graceful block).

Migration check: not needed. New env vars: NEXT_PUBLIC_TURNSTILE_SITE_KEY, TURNSTILE_SECRET_KEY (set in .env.local and Vercel Preview/Production).

Note on e2e: no Playwright test submits the login form, so the widget does not affect the existing e2e suite. If a login e2e flow is added later, use Cloudflare's always-pass test sitekey (e.g. 1x00000000000000000000AA) via env for local/test runs.

<!-- before-and-after:start -->
> Before/after by agent-browser demo

Demo captures from a local dev build using Cloudflare's always-pass test sitekey (`1x00000000000000000000AA`); the Vercel preview can't show the widget until `NEXT_PUBLIC_TURNSTILE_SITE_KEY`/`TURNSTILE_SECRET_KEY` are configured. In headless capture the widget renders as the 65px guard slot + hidden token input rather than the interactive checkbox.

| Before (Desktop) | After (Desktop) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/eb868182-1ef8-425d-bf6c-251bb0f3f0fb) | ![After](https://github.com/user-attachments/assets/f1e090b5-b703-4099-b20c-67de0f1a69b2) |

<!-- before-and-after:end -->
